### PR TITLE
Refactor: safer driver

### DIFF
--- a/crates/evm/src/driver.rs
+++ b/crates/evm/src/driver.rs
@@ -168,17 +168,17 @@ impl<'a, 'b> SignetDriver<'a, 'b> {
     }
 
     /// Get the extracts being executed by the driver.
-    pub fn extracts(&self) -> &Extracts<'b> {
+    pub const fn extracts(&self) -> &Extracts<'b> {
         self.extracts
     }
 
     /// Get the parent header.
-    pub fn parent(&self) -> &SealedHeader {
+    pub const fn parent(&self) -> &SealedHeader {
         &self.parent
     }
 
     /// Get the system constants.
-    pub fn constants(&self) -> &SignetSystemConstants {
+    pub const fn constants(&self) -> &SignetSystemConstants {
         &self.constants
     }
 


### PR DESCRIPTION
Cleanup: prevent people from changing the extracts or parent once the driver is set up

based on #13 