### PR TITLE
feat(ci): make CI also dispatchable manually

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,6 +1,7 @@
 name: CI # Continuous Integration
 
 on:
+  workflow_dispatch:
   push:
     branches: [main]
   pull_request:


### PR DESCRIPTION
Makes the CI manually dispatchable in the actions tab as well.
