### PR TITLE
fix: serve rpc over the root instead of /rpc

### DIFF
--- a/crates/rpc/src/lib.rs
+++ b/crates/rpc/src/lib.rs
@@ -93,7 +93,7 @@ pub async fn serve_axum(
 
     let cors = CorsLayer::new().allow_methods([Method::GET, Method::POST]).allow_origin(cors);
 
-    let service = router.clone().into_axum("/rpc").layer(cors);
+    let service = router.clone().into_axum("/").layer(cors);
 
     let listener = tokio::net::TcpListener::bind(addrs).await?;
 


### PR DESCRIPTION
prefer the rpc be served over the root path `/` instead of `/rpc`