### PR TITLE
feat: serve router over ws

### DIFF
--- a/crates/rpc/src/config.rs
+++ b/crates/rpc/src/config.rs
@@ -1,5 +1,5 @@
 use ajj::{pubsub::ServerShutdown, Router};
-use reth::tasks::TaskExecutor;
+use reth::{args::RpcServerArgs, tasks::TaskExecutor};
 use std::net::SocketAddr;
 use tokio::task::JoinHandle;
 
@@ -47,6 +47,24 @@ pub struct ServeConfig {
     pub cors: Option<String>,
     /// IPC name info.
     pub ipc: Option<String>,
+}
+
+impl From<RpcServerArgs> for ServeConfig {
+    fn from(args: RpcServerArgs) -> Self {
+        let http = if args.http {
+            vec![SocketAddr::from((args.http_addr, args.http_port))]
+        } else {
+            vec![]
+        };
+        let ws =
+            if args.ws { vec![SocketAddr::from((args.ws_addr, args.ws_port))] } else { vec![] };
+
+        let cors = args.http_corsdomain;
+
+        let ipc = if !args.ipcdisable { Some(args.ipcpath) } else { None };
+
+        Self { http, ws, cors, ipc }
+    }
 }
 
 impl ServeConfig {

--- a/crates/rpc/src/config.rs
+++ b/crates/rpc/src/config.rs
@@ -1,0 +1,101 @@
+use ajj::{pubsub::ServerShutdown, Router};
+use reth::tasks::TaskExecutor;
+use std::net::SocketAddr;
+use tokio::task::JoinHandle;
+
+use crate::util::{serve_axum, serve_ipc, serve_ws};
+
+/// Guard to shutdown the RPC servers. When dropped, this will shutdown all
+/// running servers
+#[derive(Default)]
+pub struct RpcServerGuard {
+    http: Option<tokio::task::JoinHandle<()>>,
+    ws: Option<tokio::task::JoinHandle<()>>,
+    ipc: Option<ServerShutdown>,
+}
+
+impl core::fmt::Debug for RpcServerGuard {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("RpcServerGuard")
+            .field("http", &self.http.is_some())
+            .field("ipc", &self.ipc.is_some())
+            .field("ws", &self.ws.is_some())
+            .finish()
+    }
+}
+
+impl Drop for RpcServerGuard {
+    fn drop(&mut self) {
+        if let Some(http) = self.http.take() {
+            http.abort();
+        }
+        if let Some(ws) = self.ws.take() {
+            ws.abort();
+        }
+        // IPC is handled by its own drop guards.
+    }
+}
+
+/// Configuration for the RPC server.
+#[derive(Clone, Debug)]
+pub struct ServeConfig {
+    /// HTTP server addresses.
+    pub http: Vec<SocketAddr>,
+    /// WS server addresses.
+    pub ws: Vec<SocketAddr>,
+    /// CORS header to be used for HTTP and WS servers (if any).
+    pub cors: Option<String>,
+    /// IPC name info.
+    pub ipc: Option<String>,
+}
+
+impl ServeConfig {
+    /// Serve the router on the given addresses.
+    async fn serve_http(
+        &self,
+        tasks: &TaskExecutor,
+        router: Router<()>,
+    ) -> eyre::Result<Option<JoinHandle<()>>> {
+        if self.http.is_empty() {
+            return Ok(None);
+        }
+        serve_axum(tasks, router, &self.http, self.cors.as_deref()).await.map(Some)
+    }
+
+    /// Serve the router on the given addresses.
+    async fn serve_ws(
+        &self,
+        tasks: &TaskExecutor,
+        router: Router<()>,
+    ) -> eyre::Result<Option<JoinHandle<()>>> {
+        if self.ws.is_empty() {
+            return Ok(None);
+        }
+        serve_ws(tasks, router, &self.ws, self.cors.as_deref()).await.map(Some)
+    }
+
+    /// Serve the router on the given ipc path.
+    async fn serve_ipc(
+        &self,
+        tasks: &TaskExecutor,
+        router: &Router<()>,
+    ) -> eyre::Result<Option<ServerShutdown>> {
+        let Some(endpoint) = &self.ipc else { return Ok(None) };
+        let shutdown = serve_ipc(tasks, router, endpoint).await?;
+        Ok(Some(shutdown))
+    }
+
+    /// Serve the router.
+    pub async fn serve(
+        &self,
+        tasks: &TaskExecutor,
+        router: Router<()>,
+    ) -> eyre::Result<RpcServerGuard> {
+        let (http, ws, ipc) = tokio::try_join!(
+            self.serve_http(tasks, router.clone()),
+            self.serve_ws(tasks, router.clone()),
+            self.serve_ipc(tasks, &router),
+        )?;
+        Ok(RpcServerGuard { http, ws, ipc })
+    }
+}

--- a/crates/rpc/src/lib.rs
+++ b/crates/rpc/src/lib.rs
@@ -23,8 +23,9 @@
 //!
 //! let cfg = ServeConfig {
 //!     http: vec!["localhost:8080".parse()?],
+//!     http_cors: None,
 //!     ws: vec![],
-//!     cors: None,
+//!     ws_cors: None,
 //!     ipc: None,
 //! };
 //!

--- a/crates/rpc/src/lib.rs
+++ b/crates/rpc/src/lib.rs
@@ -12,7 +12,7 @@
 //! # use signet_rpc::{Pnt, RpcCtx};
 //! # use reth_node_api::FullNodeComponents;
 //! # use reth::tasks::TaskExecutor;
-//! use signet_rpc::{router, serve_axum};
+//! use signet_rpc::{router, ServeConfig};
 //!
 //! # pub async fn f<Host, Signet>(ctx: RpcCtx<Host, Signet>, tasks: &TaskExecutor) -> eyre::Result<()>
 //! # where
@@ -20,13 +20,17 @@
 //! #   Signet: Pnt,
 //! # {
 //! let router = signet_rpc::router().with_state(ctx);
-//! // Spawn the server on the given addresses.
-//! let _ = serve_axum(
-//!     tasks,
-//!     &router,
-//!     &["localhost:8080".parse()?],
-//!     None
-//! ).await?;
+//!
+//! let cfg = ServeConfig {
+//!     http: vec!["localhost:8080".parse()?],
+//!     ws: vec![],
+//!     cors: None,
+//!     ipc: None,
+//! };
+//!
+//! // Spawn the server on the given addresses, the shutdown guard
+//! // will shutdown the server(s) when dropped.
+//! let shutdown_guard = cfg.serve(tasks, router).await?;
 //! # Ok(())
 //! # }
 //! ```
@@ -43,6 +47,9 @@
 #![deny(unused_must_use, rust_2018_idioms)]
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 
+mod config;
+pub use config::{RpcServerGuard, ServeConfig};
+
 mod ctx;
 pub use ctx::RpcCtx;
 
@@ -57,24 +64,15 @@ mod interest;
 mod forwarder;
 use forwarder::TxCacheForwarder;
 
-pub(crate) mod util;
+/// Utils and simple serve functions.
+pub mod util;
 pub use util::Pnt;
 
 /// Re-exported for convenience
 pub use ::ajj;
 
-use ajj::{
-    pubsub::{Connect, ServerShutdown},
-    Router,
-};
-use axum::http::{HeaderValue, Method};
-use interprocess::local_socket as ls;
-use reth::tasks::TaskExecutor;
+use ajj::Router;
 use reth_node_api::FullNodeComponents;
-use std::{future::IntoFuture, net::SocketAddr};
-use tokio::task::JoinHandle;
-use tower_http::cors::{AllowOrigin, CorsLayer};
-use tracing::error;
 
 /// Create a new router with the given host and signet types.
 pub fn router<Host, Signet>() -> Router<ctx::RpcCtx<Host, Signet>>
@@ -83,85 +81,4 @@ where
     Signet: Pnt,
 {
     ajj::Router::new().nest("eth", eth::<Host, Signet>()).nest("signet", signet::<Host, Signet>())
-}
-
-fn make_cors(cors: Option<&str>) -> CorsLayer {
-    let cors = cors
-        .unwrap_or("*")
-        .parse::<HeaderValue>()
-        .map(Into::<AllowOrigin>::into)
-        .unwrap_or_else(|_| AllowOrigin::any());
-
-    CorsLayer::new().allow_methods([Method::GET, Method::POST]).allow_origin(cors)
-}
-
-/// Serve the axum router on the specified addresses.
-async fn serve(
-    tasks: &TaskExecutor,
-    addrs: &[SocketAddr],
-    service: axum::Router,
-) -> Result<JoinHandle<()>, eyre::Error> {
-    let listener = tokio::net::TcpListener::bind(addrs).await?;
-
-    let fut = async move {
-        match axum::serve(listener, service).into_future().await {
-            Ok(_) => (),
-            Err(err) => error!(%err, "Error serving RPC via axum"),
-        }
-    };
-
-    Ok(tasks.spawn(fut))
-}
-
-/// Serve the router on the given addresses using axum.
-pub async fn serve_axum(
-    tasks: &TaskExecutor,
-    router: Router<()>,
-    addrs: &[SocketAddr],
-    cors: Option<&str>,
-) -> eyre::Result<JoinHandle<()>> {
-    let handle = tasks.handle().clone();
-    let cors = make_cors(cors);
-
-    let service = router.into_axum_with_handle("/", handle).layer(cors);
-
-    serve(tasks, addrs, service).await
-}
-
-/// Serve the router on the given address using a Websocket.
-pub async fn serve_ws(
-    tasks: &TaskExecutor,
-    router: Router<()>,
-    addrs: &[SocketAddr],
-    cors: Option<&str>,
-) -> eyre::Result<JoinHandle<()>> {
-    let handle = tasks.handle().clone();
-    let cors = make_cors(cors);
-
-    let service = router.into_axum_with_ws_and_handle("/", "/ws", handle).layer(cors);
-
-    serve(tasks, addrs, service).await
-}
-
-fn to_name(path: &std::ffi::OsStr) -> std::io::Result<ls::Name<'_>> {
-    if cfg!(windows) && !path.as_encoded_bytes().starts_with(br"\\.\pipe\") {
-        ls::ToNsName::to_ns_name::<ls::GenericNamespaced>(path)
-    } else {
-        ls::ToFsName::to_fs_name::<ls::GenericFilePath>(path)
-    }
-}
-
-/// Serve the router on the given address using IPC.
-pub async fn serve_ipc(
-    tasks: &TaskExecutor,
-    router: &Router<()>,
-    endpoint: &str,
-) -> eyre::Result<ServerShutdown> {
-    let name = std::ffi::OsStr::new(endpoint);
-    let name = to_name(name).expect("invalid name");
-    ls::ListenerOptions::new()
-        .name(name)
-        .serve_with_handle(router.clone(), tasks.handle().clone())
-        .await
-        .map_err(Into::into)
 }

--- a/crates/rpc/src/lib.rs
+++ b/crates/rpc/src/lib.rs
@@ -92,8 +92,7 @@ fn make_cors(cors: Option<&str>) -> CorsLayer {
         .map(Into::<AllowOrigin>::into)
         .unwrap_or_else(|_| AllowOrigin::any());
 
-    let cors = CorsLayer::new().allow_methods([Method::GET, Method::POST]).allow_origin(cors);
-    cors
+    CorsLayer::new().allow_methods([Method::GET, Method::POST]).allow_origin(cors)
 }
 
 /// Serve the router on the given addresses using axum.

--- a/crates/rpc/src/util.rs
+++ b/crates/rpc/src/util.rs
@@ -160,7 +160,7 @@ pub async fn serve_ws(
     let handle = tasks.handle().clone();
     let cors = make_cors(cors);
 
-    let service = router.into_axum_with_ws_and_handle("/", "/ws", handle).layer(cors);
+    let service = router.into_axum_with_ws_and_handle("/rpc", "/", handle).layer(cors);
 
     serve(tasks, addrs, service).await
 }


### PR DESCRIPTION
- impls `crate::serve_ws` to serve the router over both HTTP and WS
- ports `RpcServerGuard` from node
- adds `ServeConfig` 
- `impl From<reth::RpcServerArgs> for ServeConfig`

cc @rswanson are the routes `/` and `/ws` reasonable? edit: @Evalir pointed out it's traditional in eth to use a different port