### PR TITLE
dep: upgrade to trevm 0.20.7

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ signet-zenith = { path = "crates/zenith" }
 ajj = { version = "0.3.1" }
 
 # trevm
-trevm = { version = "0.20.4", features = ["full_env_cfg"] }
+trevm = { version = "0.20.7", features = ["full_env_cfg"] }
 
 # Alloy periphery crates
 alloy = { version = "=0.12.6", features = ["full", "rpc-types-mev", "genesis", "arbitrary"] }

--- a/crates/bundle/src/call/driver.rs
+++ b/crates/bundle/src/call/driver.rs
@@ -1,11 +1,11 @@
 use crate::{SignetCallBundle, SignetCallBundleResponse};
 use alloy::{consensus::TxEnvelope, primitives::U256};
-use signet_evm::{DriveBundleResult, EvmNeedsTx, EvmTransacted, OrderDetector};
+use signet_evm::SignetInspector;
 use std::fmt::Debug;
 use tracing::{debug_span, instrument, Level};
 use trevm::{
     helpers::Ctx,
-    revm::{context::result::EVMError, Database, DatabaseCommit, Inspector},
+    revm::{context::result::EVMError, Database, DatabaseCommit},
     trevm_bail, trevm_ensure, trevm_try, BundleDriver, BundleError,
 };
 
@@ -59,14 +59,14 @@ impl SignetBundleDriver<'_> {
     /// details into the response.
     fn accept_and_accumulate<Db, Insp>(
         &mut self,
-        trevm: EvmTransacted<Db, Insp>,
+        trevm: trevm::EvmTransacted<Db, Insp>,
         tx: &TxEnvelope,
         pre_sim_coinbase_balance: &mut U256,
         basefee: u64,
-    ) -> DriveBundleResult<Db, Self, Insp>
+    ) -> trevm::DriveBundleResult<Db, Insp, Self>
     where
         Db: Database + DatabaseCommit,
-        OrderDetector<Insp>: Inspector<Ctx<Db>>,
+        Insp: SignetInspector<Ctx<Db>>,
     {
         let beneficiary = trevm.beneficiary();
 
@@ -100,15 +100,18 @@ impl SignetBundleDriver<'_> {
 // [`BundleDriver`] Implementation for [`SignetCallBundle`].
 // This is useful mainly for the `signet_simBundle` endpoint,
 // which is used to simulate a signet bundle while respecting aggregate fills.
-impl<Insp> BundleDriver<OrderDetector<Insp>> for SignetBundleDriver<'_> {
-    type Error<Db: Database + DatabaseCommit> = BundleError<Db>;
+impl<Db, Insp> BundleDriver<Db, Insp> for SignetBundleDriver<'_>
+where
+    Db: Database + DatabaseCommit,
+    Insp: SignetInspector<Ctx<Db>>,
+{
+    type Error = BundleError<Db>;
 
     #[instrument(skip_all, level = Level::DEBUG)]
-    fn run_bundle<Db>(&mut self, trevm: EvmNeedsTx<Db, Insp>) -> DriveBundleResult<Db, Self, Insp>
-    where
-        Db: Database + DatabaseCommit,
-        OrderDetector<Insp>: Inspector<Ctx<Db>>,
-    {
+    fn run_bundle(
+        &mut self,
+        trevm: trevm::EvmNeedsTx<Db, Insp>,
+    ) -> trevm::DriveBundleResult<Db, Insp, Self> {
         // convenience binding to make usage later less verbose
         let bundle = &self.bundle.bundle;
 
@@ -184,7 +187,8 @@ impl<Insp> BundleDriver<OrderDetector<Insp>> for SignetBundleDriver<'_> {
             self.response.bundle_hash = self.bundle.bundle_hash();
 
             // Taking these clears the order detector
-            let (orders, fills) = trevm.inner_mut_unchecked().data.inspector.take_aggregates();
+            let (orders, fills) =
+                trevm.inner_mut_unchecked().data.inspector.as_mut_detector().take_aggregates();
             self.response.orders = orders;
             self.response.fills = fills;
 
@@ -193,11 +197,7 @@ impl<Insp> BundleDriver<OrderDetector<Insp>> for SignetBundleDriver<'_> {
         })
     }
 
-    fn post_bundle<Db>(&mut self, _trevm: &EvmNeedsTx<Db, Insp>) -> Result<(), Self::Error<Db>>
-    where
-        Db: Database + DatabaseCommit,
-        OrderDetector<Insp>: Inspector<Ctx<Db>>,
-    {
+    fn post_bundle(&mut self, _trevm: &trevm::EvmNeedsTx<Db, Insp>) -> Result<(), Self::Error> {
         Ok(())
     }
 }

--- a/crates/bundle/src/call/ty.rs
+++ b/crates/bundle/src/call/ty.rs
@@ -36,6 +36,7 @@ pub struct SignetCallBundle {
 
 impl SignetCallBundle {
     /// Returns the transactions in this bundle.
+    #[allow(clippy::missing_const_for_fn)] // false positive
     pub fn txs(&self) -> &[Bytes] {
         &self.bundle.txs
     }

--- a/crates/bundle/src/send.rs
+++ b/crates/bundle/src/send.rs
@@ -30,6 +30,7 @@ pub struct SignetEthBundle {
 
 impl SignetEthBundle {
     /// Returns the transactions in this bundle.
+    #[allow(clippy::missing_const_for_fn)] // false positive
     pub fn txs(&self) -> &[Bytes] {
         &self.bundle.txs
     }

--- a/crates/evm/src/aliases.rs
+++ b/crates/evm/src/aliases.rs
@@ -66,8 +66,8 @@ pub type EvmErrored<Db, I = NoOpInspector, E = EVMError<<Db as Database>::Error>
     trevm::EvmErrored<Db, SignetLayered<I>, E>;
 
 /// The result of running transactions for a block driver.
-pub type RunTxResult<Db, T, I = NoOpInspector> = trevm::RunTxResult<Db, SignetLayered<I>, T>;
+pub type RunTxResult<T, Db, I = NoOpInspector> = trevm::RunTxResult<T, Db, SignetLayered<I>>;
 
 /// The result of driving a bundle.
-pub type DriveBundleResult<Db, T, I = NoOpInspector> =
-    trevm::DriveBundleResult<Db, SignetLayered<I>, T>;
+pub type DriveBundleResult<T, Db, I = NoOpInspector> =
+    trevm::DriveBundleResult<T, Db, SignetLayered<I>>;

--- a/crates/evm/src/aliases.rs
+++ b/crates/evm/src/aliases.rs
@@ -5,6 +5,9 @@ use trevm::{
     Block, Cfg, Trevm,
 };
 
+/// Layered inspector containing an [`OrderDetector`].
+pub type SignetLayered<I> = trevm::inspectors::Layered<I, OrderDetector>;
+
 /// A [`Trevm`] that requires a [`Cfg`].
 ///
 /// Expected continuations include:
@@ -12,7 +15,7 @@ use trevm::{
 ///
 /// [`Cfg`]: trevm::Cfg
 /// [`Trevm`]: trevm::Trevm
-pub type EvmNeedsCfg<Db, I = NoOpInspector> = trevm::EvmNeedsCfg<Db, OrderDetector<I>>;
+pub type EvmNeedsCfg<Db, I = NoOpInspector> = trevm::EvmNeedsCfg<Db, SignetLayered<I>>;
 
 /// A [`Trevm`] that requires a [`Block`] and contains no
 /// outputs. This EVM has not yet executed any transactions or state changes.
@@ -22,7 +25,7 @@ pub type EvmNeedsCfg<Db, I = NoOpInspector> = trevm::EvmNeedsCfg<Db, OrderDetect
 ///
 /// [`Block`]: trevm::Block
 /// [`Trevm`]: trevm::Trevm
-pub type EvmNeedsBlock<Db, I = NoOpInspector> = trevm::EvmNeedsBlock<Db, OrderDetector<I>>;
+pub type EvmNeedsBlock<Db, I = NoOpInspector> = trevm::EvmNeedsBlock<Db, SignetLayered<I>>;
 
 /// A [`Trevm`] that requires a [`Tx`].
 ///
@@ -33,7 +36,7 @@ pub type EvmNeedsBlock<Db, I = NoOpInspector> = trevm::EvmNeedsBlock<Db, OrderDe
 ///
 /// [`Tx`]: trevm::Tx
 /// [`Trevm`]: trevm::Trevm
-pub type EvmNeedsTx<Db, I = NoOpInspector> = trevm::EvmNeedsTx<Db, OrderDetector<I>>;
+pub type EvmNeedsTx<Db, I = NoOpInspector> = trevm::EvmNeedsTx<Db, SignetLayered<I>>;
 
 /// A [`Trevm`] that is ready to execute a transaction.
 ///
@@ -41,7 +44,7 @@ pub type EvmNeedsTx<Db, I = NoOpInspector> = trevm::EvmNeedsTx<Db, OrderDetector
 /// with [`EvmReady::clear_tx`].
 ///
 /// [`Trevm`]: trevm::Trevm
-pub type EvmReady<Db, I = NoOpInspector> = trevm::EvmReady<Db, OrderDetector<I>>;
+pub type EvmReady<Db, I = NoOpInspector> = trevm::EvmReady<Db, SignetLayered<I>>;
 
 /// A [`Trevm`] that encountered an error during transaction execution.
 ///
@@ -50,7 +53,7 @@ pub type EvmReady<Db, I = NoOpInspector> = trevm::EvmReady<Db, OrderDetector<I>>
 /// - [`EvmTransacted::accept`]
 ///
 /// [`Trevm`]: trevm::Trevm
-pub type EvmTransacted<Db, I = NoOpInspector> = trevm::EvmTransacted<Db, OrderDetector<I>>;
+pub type EvmTransacted<Db, I = NoOpInspector> = trevm::EvmTransacted<Db, SignetLayered<I>>;
 
 /// A [`Trevm`] that encountered an error during transaction execution.
 ///
@@ -60,11 +63,11 @@ pub type EvmTransacted<Db, I = NoOpInspector> = trevm::EvmTransacted<Db, OrderDe
 ///
 /// [`Trevm`]: trevm::Trevm
 pub type EvmErrored<Db, I = NoOpInspector, E = EVMError<<Db as Database>::Error>> =
-    trevm::EvmErrored<Db, OrderDetector<I>, E>;
+    trevm::EvmErrored<Db, SignetLayered<I>, E>;
 
 /// The result of running transactions for a block driver.
-pub type RunTxResult<Db, T, I = NoOpInspector> = trevm::RunTxResult<Db, OrderDetector<I>, T>;
+pub type RunTxResult<Db, T, I = NoOpInspector> = trevm::RunTxResult<Db, SignetLayered<I>, T>;
 
 /// The result of driving a bundle.
 pub type DriveBundleResult<Db, T, I = NoOpInspector> =
-    trevm::DriveBundleResult<Db, OrderDetector<I>, T>;
+    trevm::DriveBundleResult<Db, SignetLayered<I>, T>;

--- a/crates/evm/src/orders/mod.rs
+++ b/crates/evm/src/orders/mod.rs
@@ -3,3 +3,52 @@ pub use framed::{Framed, FramedFilleds, FramedOrders};
 
 mod inspector;
 pub use inspector::OrderDetector;
+
+use reth::revm::interpreter::{interpreter::EthInterpreter, InterpreterTypes};
+use trevm::{
+    helpers::Ctx,
+    inspectors::Layered,
+    revm::{Database, Inspector},
+};
+
+/// Inspector containing an accessible [`OrderDetector`].
+pub trait SignetInspector<Ctx, Int = EthInterpreter>: Inspector<Ctx, Int>
+where
+    Int: InterpreterTypes,
+{
+    /// Get a reference to the inner [`OrderDetector`].
+    fn as_detector(&self) -> &OrderDetector;
+
+    /// Get a mutable reference to the inner [`OrderDetector`].
+    fn as_mut_detector(&mut self) -> &mut OrderDetector;
+}
+
+impl<Db, T, I, Int> SignetInspector<Ctx<Db>, Int> for Layered<T, I>
+where
+    Db: Database,
+    T: Inspector<Ctx<Db>, Int>,
+    I: SignetInspector<Ctx<Db>, Int>,
+    Int: InterpreterTypes,
+{
+    fn as_detector(&self) -> &OrderDetector {
+        self.inner().as_detector()
+    }
+
+    fn as_mut_detector(&mut self) -> &mut OrderDetector {
+        self.inner_mut().as_mut_detector()
+    }
+}
+
+impl<Db, Int> SignetInspector<Ctx<Db>, Int> for OrderDetector
+where
+    Int: InterpreterTypes,
+    Db: Database,
+{
+    fn as_detector(&self) -> &OrderDetector {
+        self
+    }
+
+    fn as_mut_detector(&mut self) -> &mut OrderDetector {
+        self
+    }
+}

--- a/crates/extract/src/block.rs
+++ b/crates/extract/src/block.rs
@@ -33,13 +33,13 @@ impl Extracts<'_> {
     }
 
     /// Get the host block number.
-    pub fn host_block_number(&self) -> u64 {
-        self.host_block.number
+    pub const fn host_block_number(&self) -> u64 {
+        self.host_block.sealed_block().header().number
     }
 
     /// Get the host block timestamp.
-    pub fn host_block_timestamp(&self) -> u64 {
-        self.host_block.timestamp
+    pub const fn host_block_timestamp(&self) -> u64 {
+        self.host_block.sealed_block().header().timestamp
     }
 
     /// True if the host block contains a [`BlockSubmitted`] event.

--- a/crates/types/src/magic_sig.rs
+++ b/crates/types/src/magic_sig.rs
@@ -125,7 +125,7 @@ impl MagicSigInfo {
 ///     for transact).
 ///   - `[9..12]`: A 3-byte RESERVED region.
 ///   - `[12..32]`: For transact events, (flag byte 3) the sender's address.
-///      RESERVED otherwise.
+///     RESERVED otherwise.
 ///
 /// Because Ethereum-like chains enforce low-S signatures, the S value of the
 /// magic signature is invalid for Ethereum-based chains supporting [EIP-2].

--- a/crates/zenith/src/bindings.rs
+++ b/crates/zenith/src/bindings.rs
@@ -263,11 +263,13 @@ mod orders {
 
     impl Orders::Order {
         /// Get the inputs of the order.
+        #[allow(clippy::missing_const_for_fn)] // false positive
         pub fn inputs(&self) -> &[IOrders::Input] {
             &self.inputs
         }
 
         /// Get the outputs of the order.
+        #[allow(clippy::missing_const_for_fn)] // false positive
         pub fn outputs(&self) -> &[IOrders::Output] {
             &self.outputs
         }

--- a/crates/zenith/src/block.rs
+++ b/crates/zenith/src/block.rs
@@ -121,6 +121,7 @@ where
     }
 
     /// Access to the transactions.
+    #[allow(clippy::missing_const_for_fn)] // false positive
     pub fn transactions(&self) -> &[C::Tx] {
         &self.transactions
     }


### PR DESCRIPTION
- Restore DB to driver traits to handle revm@20
- Migrate to `Layered`
- Add `SignetInspector` trait
- move generics to new trevm order