### PR TITLE
fix(rpc): introduce in-house `build_signet_receipt` to build receipts

### DIFF
--- a/crates/rpc/src/ctx.rs
+++ b/crates/rpc/src/ctx.rs
@@ -1,7 +1,7 @@
 use crate::{
     eth::EthError,
     interest::{ActiveFilter, FilterManager, FilterOutput, SubscriptionManager},
-    receipts::SignetReceiptBuilder,
+    receipts::build_signet_receipt,
     util::BlockRangeInclusiveIter,
     Pnt, TxCacheForwarder,
 };
@@ -493,9 +493,7 @@ where
             return Ok(None);
         };
 
-        SignetReceiptBuilder::new(&tx, meta, &receipt, &all_receipts)
-            .map(SignetReceiptBuilder::build)
-            .map(Some)
+        build_signet_receipt(&tx, meta, &receipt, &all_receipts).map(Some)
     }
 
     /// Create the [`Block`] object for a specific [`BlockId`].

--- a/crates/rpc/src/ctx.rs
+++ b/crates/rpc/src/ctx.rs
@@ -1,6 +1,7 @@
 use crate::{
     eth::EthError,
     interest::{ActiveFilter, FilterManager, FilterOutput, SubscriptionManager},
+    receipts::SignetReceiptBuilder,
     util::BlockRangeInclusiveIter,
     Pnt, TxCacheForwarder,
 };
@@ -29,8 +30,8 @@ use reth::{
                 calculate_reward_percentiles_for_block, fee_history_cache_new_blocks_task,
             },
             logs_utils::{self, append_matching_block_logs, ProviderOrBlock},
-            EthApiError, EthConfig, EthReceiptBuilder, EthStateCache, FeeHistoryCache,
-            FeeHistoryEntry, GasPriceOracle,
+            EthApiError, EthConfig, EthStateCache, FeeHistoryCache, FeeHistoryEntry,
+            GasPriceOracle,
         },
         types::{FilterBlockOption, FilteredParams},
     },
@@ -492,9 +493,8 @@ where
             return Ok(None);
         };
 
-        // last arg is blobparams, which we don't have
-        EthReceiptBuilder::new(&tx, meta, &receipt, &all_receipts, None)
-            .map(EthReceiptBuilder::build)
+        SignetReceiptBuilder::new(&tx, meta, &receipt, &all_receipts)
+            .map(SignetReceiptBuilder::build)
             .map(Some)
     }
 

--- a/crates/rpc/src/ctx.rs
+++ b/crates/rpc/src/ctx.rs
@@ -493,7 +493,7 @@ where
             return Ok(None);
         };
 
-        build_signet_receipt(&tx, meta, &receipt, &all_receipts).map(Some)
+        build_signet_receipt(tx, meta, receipt, all_receipts.to_vec()).map(Some)
     }
 
     /// Create the [`Block`] object for a specific [`BlockId`].

--- a/crates/rpc/src/eth/endpoints.rs
+++ b/crates/rpc/src/eth/endpoints.rs
@@ -2,6 +2,7 @@ use crate::{
     ctx::RpcCtx,
     eth::{CallErrorData, EthError},
     interest::{FilterOutput, InterestKind},
+    receipts::SignetReceiptBuilder,
     util::{await_jh_option, await_jh_option_response, response_tri},
     Pnt,
 };
@@ -22,7 +23,6 @@ use reth::{
     network::NetworkInfo,
     primitives::TransactionMeta,
     providers::{BlockNumReader, StateProviderFactory, TransactionsProvider},
-    rpc::server_types::eth::EthReceiptBuilder,
 };
 use reth_node_api::FullNodeComponents;
 use reth_rpc_eth_api::{RpcBlock, RpcHeader, RpcReceipt, RpcTransaction};
@@ -203,8 +203,7 @@ where
                     excess_blob_gas,
                     timestamp,
                 };
-                // last arg is blob params, which we'll never have
-                EthReceiptBuilder::new(tx, meta, receipt, &receipts, None)
+                SignetReceiptBuilder::new(tx, meta, receipt, &receipts)
                     .map(|builder| builder.build())
             })
             .collect::<Result<Vec<_>, _>>()

--- a/crates/rpc/src/eth/endpoints.rs
+++ b/crates/rpc/src/eth/endpoints.rs
@@ -2,7 +2,7 @@ use crate::{
     ctx::RpcCtx,
     eth::{CallErrorData, EthError},
     interest::{FilterOutput, InterestKind},
-    receipts::SignetReceiptBuilder,
+    receipts::build_signet_receipt,
     util::{await_jh_option, await_jh_option_response, response_tri},
     Pnt,
 };
@@ -203,8 +203,7 @@ where
                     excess_blob_gas,
                     timestamp,
                 };
-                SignetReceiptBuilder::new(tx, meta, receipt, &receipts)
-                    .map(|builder| builder.build())
+                build_signet_receipt(tx, meta, receipt, &receipts)
             })
             .collect::<Result<Vec<_>, _>>()
             .map(Some)

--- a/crates/rpc/src/eth/endpoints.rs
+++ b/crates/rpc/src/eth/endpoints.rs
@@ -203,7 +203,7 @@ where
                     excess_blob_gas,
                     timestamp,
                 };
-                build_signet_receipt(tx, meta, receipt, &receipts)
+                build_signet_receipt(tx.to_owned(), meta, receipt.to_owned(), receipts.to_vec())
             })
             .collect::<Result<Vec<_>, _>>()
             .map(Some)

--- a/crates/rpc/src/lib.rs
+++ b/crates/rpc/src/lib.rs
@@ -65,6 +65,8 @@ mod interest;
 mod forwarder;
 pub use forwarder::TxCacheForwarder;
 
+pub mod receipts;
+
 /// Utils and simple serve functions.
 pub mod util;
 pub use util::Pnt;

--- a/crates/rpc/src/receipts.rs
+++ b/crates/rpc/src/receipts.rs
@@ -1,0 +1,137 @@
+//! Signet RPC receipt response builder.
+
+use alloy::consensus::{transaction::TransactionMeta, ReceiptEnvelope, TxReceipt};
+use alloy::primitives::{Address, TxKind};
+use alloy::rpc::types::eth::{Log, ReceiptWithBloom, TransactionReceipt};
+use reth::primitives::transaction::SignedTransaction;
+use reth::primitives::{Receipt, TransactionSigned, TxType};
+use reth::rpc::server_types::eth::{EthApiError, EthResult};
+use signet_types::MagicSig;
+
+/// Builds an [`TransactionReceipt`] obtaining the inner receipt envelope from the given closure.
+pub fn build_receipt<R, T, E>(
+    transaction: &T,
+    meta: TransactionMeta,
+    receipt: &R,
+    all_receipts: &[R],
+    build_envelope: impl FnOnce(ReceiptWithBloom<alloy::consensus::Receipt<Log>>) -> E,
+) -> EthResult<TransactionReceipt<E>>
+where
+    R: TxReceipt<Log = alloy::primitives::Log>,
+    T: SignedTransaction,
+{
+    // Recover the transaction sender.
+    // Some transactions are emitted by Signet itself in behalf of the sender,
+    // in which case they'll use [`MagicSig`]s to preserve the sender with additional metadata.
+    // Therefore, in case recovering the signer fails, we try to parse the signature as a magic signature.
+    let from = match transaction.recover_signer_unchecked() {
+        Ok(address) => address,
+        Err(_) => {
+            // If the transaction is not signed by the sender, it is a magic signature.
+            let magic_sig = MagicSig::try_from_signature(transaction.signature())
+                .ok_or_else(|| EthApiError::InvalidTransactionSignature)?;
+            magic_sig.sender()
+        }
+    };
+
+    // get the previous transaction cumulative gas used
+    let gas_used = if meta.index == 0 {
+        receipt.cumulative_gas_used()
+    } else {
+        let prev_tx_idx = (meta.index - 1) as usize;
+        all_receipts
+            .get(prev_tx_idx)
+            .map(|prev_receipt| receipt.cumulative_gas_used() - prev_receipt.cumulative_gas_used())
+            .unwrap_or_default()
+    };
+
+    let logs_bloom = receipt.bloom();
+
+    // get number of logs in the block
+    let mut num_logs = 0;
+    for prev_receipt in all_receipts.iter().take(meta.index as usize) {
+        num_logs += prev_receipt.logs().len();
+    }
+
+    let logs: Vec<Log> = receipt
+        .logs()
+        .iter()
+        .enumerate()
+        .map(|(tx_log_idx, log)| Log {
+            inner: log.clone(),
+            block_hash: Some(meta.block_hash),
+            block_number: Some(meta.block_number),
+            block_timestamp: Some(meta.timestamp),
+            transaction_hash: Some(meta.tx_hash),
+            transaction_index: Some(meta.index),
+            log_index: Some((num_logs + tx_log_idx) as u64),
+            removed: false,
+        })
+        .collect();
+
+    let rpc_receipt = alloy::rpc::types::eth::Receipt {
+        status: receipt.status_or_post_state(),
+        cumulative_gas_used: receipt.cumulative_gas_used(),
+        logs,
+    };
+
+    let (contract_address, to) = match transaction.kind() {
+        TxKind::Create => (Some(from.create(transaction.nonce())), None),
+        TxKind::Call(addr) => (None, Some(Address(*addr))),
+    };
+
+    Ok(TransactionReceipt {
+        inner: build_envelope(ReceiptWithBloom { receipt: rpc_receipt, logs_bloom }),
+        transaction_hash: meta.tx_hash,
+        transaction_index: Some(meta.index),
+        block_hash: Some(meta.block_hash),
+        block_number: Some(meta.block_number),
+        from,
+        to,
+        gas_used,
+        contract_address,
+        effective_gas_price: transaction.effective_gas_price(meta.base_fee),
+        // Signet does not support EIP-4844, so these fields are always None.
+        blob_gas_price: None,
+        blob_gas_used: None,
+    })
+}
+
+/// Receipt response builder.
+#[derive(Debug)]
+pub struct SignetReceiptBuilder {
+    /// The base response body, contains L1 fields.
+    pub base: TransactionReceipt,
+}
+
+impl SignetReceiptBuilder {
+    /// Returns a new builder with the base response body (L1 fields) set.
+    ///
+    /// Note: This requires _all_ block receipts because we need to calculate the gas used by the
+    /// transaction.
+    pub fn new(
+        transaction: &TransactionSigned,
+        meta: TransactionMeta,
+        receipt: &Receipt,
+        all_receipts: &[Receipt],
+    ) -> EthResult<Self> {
+        let base = build_receipt(transaction, meta, receipt, all_receipts, |receipt_with_bloom| {
+            match receipt.tx_type {
+                TxType::Legacy => ReceiptEnvelope::Legacy(receipt_with_bloom),
+                TxType::Eip2930 => ReceiptEnvelope::Eip2930(receipt_with_bloom),
+                TxType::Eip1559 => ReceiptEnvelope::Eip1559(receipt_with_bloom),
+                TxType::Eip4844 => ReceiptEnvelope::Eip4844(receipt_with_bloom),
+                TxType::Eip7702 => ReceiptEnvelope::Eip7702(receipt_with_bloom),
+                #[allow(unreachable_patterns)]
+                _ => unreachable!(),
+            }
+        })?;
+
+        Ok(Self { base })
+    }
+
+    /// Builds a receipt response from the base response body, and any set additional fields.
+    pub fn build(self) -> TransactionReceipt {
+        self.base
+    }
+}

--- a/crates/rpc/src/receipts.rs
+++ b/crates/rpc/src/receipts.rs
@@ -135,3 +135,29 @@ impl SignetReceiptBuilder {
         self.base
     }
 }
+
+// Some code in this file has been copied and modified from reth
+// <https://github.com/paradigmxyz/reth>
+// The original license is included below:
+//
+// The MIT License (MIT)
+//
+// Copyright (c) 2022-2025 Reth Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//.
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.

--- a/crates/rpc/src/receipts.rs
+++ b/crates/rpc/src/receipts.rs
@@ -15,9 +15,7 @@ pub fn build_signet_receipt(
     meta: TransactionMeta,
     receipt: &Receipt,
     all_receipts: &[Receipt],
-) -> EthResult<TransactionReceipt<ReceiptEnvelope<reth::rpc::types::Log>>>
-where
-{
+) -> EthResult<TransactionReceipt<ReceiptEnvelope<reth::rpc::types::Log>>> {
     // Recover the transaction sender.
     // Some transactions are emitted by Signet itself in behalf of the sender,
     // in which case they'll use [`MagicSig`]s to preserve the sender with additional metadata.

--- a/crates/types/src/magic_sig.rs
+++ b/crates/types/src/magic_sig.rs
@@ -197,7 +197,13 @@ impl From<MagicSig> for Signature {
 
 #[cfg(test)]
 mod test {
+    use alloy::primitives::address;
+
     use super::*;
+
+    // Enter token transaction, from Pecorino.
+    // Corresponding to tx hash 0xb67ee8b269385dee5e4b454a3fe64a75e1073144cf1b71836e00e35b38e8ee5a
+    const ENTER_TOKEN_TX: &str = include_str!("../../../tests/artifacts/enter_tx.json");
 
     #[test]
     fn test_enter_roundtrip() {
@@ -228,5 +234,15 @@ mod test {
         let sig: Signature = msig.into();
 
         assert_eq!(MagicSig::try_from_signature(&sig), Some(msig))
+    }
+
+    #[test]
+    fn test_tx_decode_sig() {
+        let tx: alloy::consensus::TxEnvelope = serde_json::from_str(ENTER_TOKEN_TX).unwrap();
+        let sig = tx.signature();
+        let msig = MagicSig::try_from_signature(sig).unwrap();
+        // The sender should be equivalent to the minter address.
+        // Only on transact events the sender is the actual initiator of the tx on L1.
+        assert_eq!(msig.sender(), address!("0x00000000000000000000746f6b656e61646d696e"))
     }
 }

--- a/crates/types/src/magic_sig.rs
+++ b/crates/types/src/magic_sig.rs
@@ -197,7 +197,6 @@ impl From<MagicSig> for Signature {
 
 #[cfg(test)]
 mod test {
-    use alloy::primitives::address;
 
     use super::*;
 
@@ -243,6 +242,6 @@ mod test {
         let msig = MagicSig::try_from_signature(sig).unwrap();
         // The sender should be equivalent to the minter address.
         // Only on transact events the sender is the actual initiator of the tx on L1.
-        assert_eq!(msig.sender(), address!("0x00000000000000000000746f6b656e61646d696e"))
+        assert_eq!(msig.sender(), MINTER_ADDRESS)
     }
 }

--- a/tests/artifacts/enter_tx.json
+++ b/tests/artifacts/enter_tx.json
@@ -1,0 +1,22 @@
+{
+  "type": "0x2",
+  "chainId": "0x375e",
+  "nonce": "0xf",
+  "gas": "0x5208",
+  "maxFeePerGas": "0x0",
+  "maxPriorityFeePerGas": "0x0",
+  "to": "0x37e49992c6e467d0b4833c7fa3f87873db133763",
+  "value": "0x1bc16d674ec80000",
+  "accessList": [],
+  "input": "0x",
+  "r": "0x4f19b0633f4d8ccfec7d7ad3b54cd168d7528febaf12e5c456c3b1c66339568",
+  "s": "0xffeeddcc00000000010000000000000000000000000000000000000000000000",
+  "yParity": "0x0",
+  "v": "0x0",
+  "hash": "0xb67ee8b269385dee5e4b454a3fe64a75e1073144cf1b71836e00e35b38e8ee5a",
+  "blockHash": "0x9b388ac912c416db97b9e30a1d466cd8d2b05b1722060d1eaabb50e00dc1e78a",
+  "blockNumber": "0x23547",
+  "transactionIndex": "0x0",
+  "from": "0x00000000000000000000746f6b656e61646d696e",
+  "gasPrice": "0x7"
+}


### PR DESCRIPTION
fix(rpc): use `SignetReceiptBuilder` to build receipts

in-houses the `build_receipt` fn, to add support for transactions that use `MagicSig`s (they're not directly signed by the sender, which is the case for signet events). Usage of this type fixes both `eth_getTransactionReceipt` and `eth_getBlockReceipts`.

Closes ENG-970.