### PR TITLE
feat: SignedOrder/Fill to_tx helpers

### DIFF
--- a/crates/types/Cargo.toml
+++ b/crates/types/Cargo.toml
@@ -18,7 +18,6 @@ serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
 thiserror.workspace = true
 chrono.workspace = true
-reth.workspace = true
 
 [dev-dependencies]
 tokio = { version = "1.37.0", features = ["macros"] }

--- a/crates/types/Cargo.toml
+++ b/crates/types/Cargo.toml
@@ -11,13 +11,14 @@ repository.workspace = true
 [dependencies]
 signet-zenith.workspace = true
 
-alloy = { workspace = true, features = ["eips"] }
+alloy.workspace = true
 
 hex.workspace = true
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
 thiserror.workspace = true
 chrono.workspace = true
+reth.workspace = true
 
 [dev-dependencies]
 tokio = { version = "1.37.0", features = ["macros"] }

--- a/crates/types/src/signing/fill.rs
+++ b/crates/types/src/signing/fill.rs
@@ -1,10 +1,10 @@
 use crate::agg::AggregateOrders;
 use crate::signing::{permit_signing_info, SignedPermitError, SigningError};
 use alloy::{
-    network::TransactionBuilder, primitives::Address, signers::Signer, sol_types::SolCall,
+    network::TransactionBuilder, primitives::Address, rpc::types::TransactionRequest,
+    signers::Signer, sol_types::SolCall,
 };
 use chrono::Utc;
-use reth::rpc::types::TransactionRequest;
 use serde::{Deserialize, Serialize};
 use signet_zenith::RollupOrders::{fillPermit2Call, Output, Permit2Batch, TokenPermissions};
 use std::{borrow::Cow, collections::HashMap};

--- a/crates/types/src/signing/fill.rs
+++ b/crates/types/src/signing/fill.rs
@@ -1,9 +1,12 @@
 use crate::agg::AggregateOrders;
 use crate::signing::{permit_signing_info, SignedPermitError, SigningError};
-use alloy::{primitives::Address, signers::Signer};
+use alloy::{
+    network::TransactionBuilder, primitives::Address, signers::Signer, sol_types::SolCall,
+};
 use chrono::Utc;
+use reth::rpc::types::TransactionRequest;
 use serde::{Deserialize, Serialize};
-use signet_zenith::RollupOrders::{Output, Permit2Batch, TokenPermissions};
+use signet_zenith::RollupOrders::{fillPermit2Call, Output, Permit2Batch, TokenPermissions};
 use std::{borrow::Cow, collections::HashMap};
 
 /// SignedFill type is constructed by Fillers to fill a batch of Orders.
@@ -71,6 +74,17 @@ impl SignedFill {
         }
 
         Ok(())
+    }
+
+    /// Generate a TransactionRequest to `fill` the SignedFill.
+    pub fn to_fill_tx(&self, order_contract: Address) -> TransactionRequest {
+        // encode fill data
+        let fill_data =
+            fillPermit2Call { outputs: self.outputs.clone(), permit2: self.permit.clone() }
+                .abi_encode();
+
+        // construct fill tx request
+        TransactionRequest::default().with_input(fill_data).with_to(order_contract)
     }
 }
 

--- a/crates/types/src/signing/order.rs
+++ b/crates/types/src/signing/order.rs
@@ -1,9 +1,9 @@
 use crate::signing::{permit_signing_info, SignedPermitError, SigningError};
 use alloy::{
-    network::TransactionBuilder, primitives::Address, signers::Signer, sol_types::SolCall,
+    network::TransactionBuilder, primitives::Address, rpc::types::TransactionRequest,
+    signers::Signer, sol_types::SolCall,
 };
 use chrono::Utc;
-use reth::rpc::types::TransactionRequest;
 use serde::{Deserialize, Serialize};
 use signet_zenith::RollupOrders::{
     initiatePermit2Call, Order, Output, Permit2Batch, TokenPermissions,

--- a/crates/types/src/signing/order.rs
+++ b/crates/types/src/signing/order.rs
@@ -1,8 +1,13 @@
 use crate::signing::{permit_signing_info, SignedPermitError, SigningError};
-use alloy::{primitives::Address, signers::Signer};
+use alloy::{
+    network::TransactionBuilder, primitives::Address, signers::Signer, sol_types::SolCall,
+};
 use chrono::Utc;
+use reth::rpc::types::TransactionRequest;
 use serde::{Deserialize, Serialize};
-use signet_zenith::RollupOrders::{Order, Output, Permit2Batch, TokenPermissions};
+use signet_zenith::RollupOrders::{
+    initiatePermit2Call, Order, Output, Permit2Batch, TokenPermissions,
+};
 use std::borrow::Cow;
 
 /// A SignedOrder represents a single Order after it has been permit2-encoded and signed.
@@ -44,6 +49,24 @@ impl SignedOrder {
         }
 
         Ok(())
+    }
+
+    /// Generate a TransactionRequest to `initiate` the SignedOrder.
+    pub fn to_initiate_tx(
+        &self,
+        filler_token_recipient: Address,
+        order_contract: Address,
+    ) -> TransactionRequest {
+        // encode initiate data
+        let initiate_data = initiatePermit2Call {
+            tokenRecipient: filler_token_recipient,
+            outputs: self.outputs.clone(),
+            permit2: self.permit.clone(),
+        }
+        .abi_encode();
+
+        // construct an initiate tx request
+        TransactionRequest::default().with_input(initiate_data).with_to(order_contract)
     }
 }
 


### PR DESCRIPTION
transform a `SignedOrder` or `Fill` into the `TransactionRequests` necessary to `initiate` or `fill` them, respectively.