### PR TITLE
feat: add chain names & tx cache URL

### DIFF
--- a/crates/constants/Cargo.toml
+++ b/crates/constants/Cargo.toml
@@ -13,7 +13,6 @@ alloy.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
-reqwest.workspace = true
 
 [features]
 default = []

--- a/crates/constants/Cargo.toml
+++ b/crates/constants/Cargo.toml
@@ -13,7 +13,7 @@ alloy.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
-
+reqwest.workspace = true
 
 [features]
 default = []

--- a/crates/constants/src/chains/pecorino.rs
+++ b/crates/constants/src/chains/pecorino.rs
@@ -76,9 +76,9 @@ pub const PECORINO_SYS: SignetSystemConstants = crate::SignetSystemConstants::ne
 
 /// Signet environment constants for Pecorino.
 pub const PECORINO_ENV: SignetEnvironmentConstants = SignetEnvironmentConstants::new(
-    HOST_NAME.to_string(),
-    RU_NAME.to_string(),
-    TX_CACHE_URL.to_string(),
+    HOST_NAME,
+    RU_NAME,
+    TX_CACHE_URL,
 );
 
 /// Signet constants for Pecorino.

--- a/crates/constants/src/chains/pecorino.rs
+++ b/crates/constants/src/chains/pecorino.rs
@@ -75,11 +75,8 @@ pub const ROLLUP: RollupConstants =
 pub const PECORINO_SYS: SignetSystemConstants = crate::SignetSystemConstants::new(HOST, ROLLUP);
 
 /// Signet environment constants for Pecorino.
-pub const PECORINO_ENV: SignetEnvironmentConstants = SignetEnvironmentConstants::new(
-    HOST_NAME,
-    RU_NAME,
-    TX_CACHE_URL,
-);
+pub const PECORINO_ENV: SignetEnvironmentConstants =
+    SignetEnvironmentConstants::new(HOST_NAME, RU_NAME, TX_CACHE_URL);
 
 /// Signet constants for Pecorino.
 pub const PECORINO: SignetConstants = SignetConstants::new(PECORINO_SYS, PECORINO_ENV);

--- a/crates/constants/src/chains/pecorino.rs
+++ b/crates/constants/src/chains/pecorino.rs
@@ -1,8 +1,13 @@
 //! Constants for the Pecorino testnet.
 
-use crate::{HostConstants, PredeployTokens, RollupConstants, SignetSystemConstants};
+use crate::{
+    HostConstants, PredeployTokens, RollupConstants, SignetConstants, SignetEnvironmentConstants,
+    SignetSystemConstants,
+};
 use alloy::primitives::{address, Address};
 
+/// Name for the host chain.
+pub const HOST_NAME: &str = "Pecorino Host";
 /// Chain ID for the Pecorino testnet host chain.
 pub const HOST_CHAIN_ID: u64 = 3151908;
 /// Deployment height for the Pecorino testnet host chain.
@@ -30,6 +35,8 @@ pub const RU_USDT: Address = address!("0xF34326d3521F1b07d1aa63729cB14A372f8A737
 /// WBTC token for the Pecorino testnet RU chain.
 pub const RU_WBTC: Address = address!("0xE3d7066115f7d6b65F88Dff86288dB4756a7D733");
 
+/// Name for the network.
+pub const RU_NAME: &str = "Pecorino";
 /// Chain ID for the Pecorino testnet RU chain.
 pub const RU_CHAIN_ID: u64 = 14174;
 /// `Orders` contract address for the Pecorino testnet RU chain.
@@ -45,6 +52,9 @@ pub const HOST_TOKENS: PredeployTokens =
 
 /// RU system tokens for Pecorino.
 pub const RU_TOKENS: PredeployTokens = crate::PredeployTokens::new(RU_USDC, RU_USDT, RU_WBTC);
+
+/// The URL of the Transaction Cache endpoint.
+pub const TX_CACHE_URL: &str = "https://transactions.pecorino.signet.sh";
 
 /// Host system constants for Pecorino.
 pub const HOST: HostConstants = crate::HostConstants::new(
@@ -62,4 +72,14 @@ pub const ROLLUP: RollupConstants =
     crate::RollupConstants::new(RU_CHAIN_ID, RU_ORDERS, RU_PASSAGE, BASE_FEE_RECIPIENT, RU_TOKENS);
 
 /// Signet system constants for Pecorino.
-pub const PECORINO: SignetSystemConstants = crate::SignetSystemConstants::new(HOST, ROLLUP);
+pub const PECORINO_SYS: SignetSystemConstants = crate::SignetSystemConstants::new(HOST, ROLLUP);
+
+/// Signet environment constants for Pecorino.
+pub const PECORINO_ENV: SignetEnvironmentConstants = SignetEnvironmentConstants::new(
+    HOST_NAME.to_string(),
+    RU_NAME.to_string(),
+    TX_CACHE_URL.to_string(),
+);
+
+/// Signet constants for Pecorino.
+pub const PECORINO: SignetConstants = SignetConstants::new(PECORINO_SYS, PECORINO_ENV);

--- a/crates/constants/src/chains/pecorino.rs
+++ b/crates/constants/src/chains/pecorino.rs
@@ -5,6 +5,7 @@ use crate::{
     SignetSystemConstants,
 };
 use alloy::primitives::{address, Address};
+use std::borrow::Cow;
 
 /// Name for the host chain.
 pub const HOST_NAME: &str = "Pecorino Host";
@@ -75,8 +76,11 @@ pub const ROLLUP: RollupConstants =
 pub const PECORINO_SYS: SignetSystemConstants = crate::SignetSystemConstants::new(HOST, ROLLUP);
 
 /// Signet environment constants for Pecorino.
-pub const PECORINO_ENV: SignetEnvironmentConstants =
-    SignetEnvironmentConstants::new(HOST_NAME, RU_NAME, TX_CACHE_URL);
+pub const PECORINO_ENV: SignetEnvironmentConstants = SignetEnvironmentConstants::new(
+    Cow::Borrowed(HOST_NAME),
+    Cow::Borrowed(RU_NAME),
+    Cow::Borrowed(TX_CACHE_URL),
+);
 
 /// Signet constants for Pecorino.
 pub const PECORINO: SignetConstants = SignetConstants::new(PECORINO_SYS, PECORINO_ENV);

--- a/crates/constants/src/chains/test_utils.rs
+++ b/crates/constants/src/chains/test_utils.rs
@@ -5,6 +5,7 @@ use crate::{
     SignetSystemConstants,
 };
 use alloy::primitives::{address, Address};
+use std::borrow::Cow;
 
 /// Default reward address used in tests when no other is specified.
 pub const DEFAULT_REWARD_ADDRESS: Address = Address::repeat_byte(0x81);
@@ -77,8 +78,11 @@ pub const ROLLUP: RollupConstants =
 pub const TEST_SYS: SignetSystemConstants = SignetSystemConstants::new(HOST, ROLLUP);
 
 /// Environment constants for unit tests.
-pub const TEST_ENV: SignetEnvironmentConstants =
-    SignetEnvironmentConstants::new(HOST_NAME, RU_NAME, TX_CACHE_URL);
+pub const TEST_ENV: SignetEnvironmentConstants = SignetEnvironmentConstants::new(
+    Cow::Borrowed(HOST_NAME),
+    Cow::Borrowed(RU_NAME),
+    Cow::Borrowed(TX_CACHE_URL),
+);
 
 /// Signet constants for Pecorino.
 pub const TEST: SignetConstants = SignetConstants::new(TEST_SYS, TEST_ENV);

--- a/crates/constants/src/chains/test_utils.rs
+++ b/crates/constants/src/chains/test_utils.rs
@@ -78,9 +78,9 @@ pub const TEST_SYS: SignetSystemConstants = SignetSystemConstants::new(HOST, ROL
 
 /// Environment constants for unit tests.
 pub const TEST_ENV: SignetEnvironmentConstants = SignetEnvironmentConstants::new(
-    HOST_NAME.to_string(),
-    RU_NAME.to_string(),
-    TX_CACHE_URL.to_string(),
+    HOST_NAME,
+    RU_NAME,
+    TX_CACHE_URL,
 );
 
 /// Signet constants for Pecorino.

--- a/crates/constants/src/chains/test_utils.rs
+++ b/crates/constants/src/chains/test_utils.rs
@@ -77,11 +77,8 @@ pub const ROLLUP: RollupConstants =
 pub const TEST_SYS: SignetSystemConstants = SignetSystemConstants::new(HOST, ROLLUP);
 
 /// Environment constants for unit tests.
-pub const TEST_ENV: SignetEnvironmentConstants = SignetEnvironmentConstants::new(
-    HOST_NAME,
-    RU_NAME,
-    TX_CACHE_URL,
-);
+pub const TEST_ENV: SignetEnvironmentConstants =
+    SignetEnvironmentConstants::new(HOST_NAME, RU_NAME, TX_CACHE_URL);
 
 /// Signet constants for Pecorino.
 pub const TEST: SignetConstants = SignetConstants::new(TEST_SYS, TEST_ENV);

--- a/crates/constants/src/chains/test_utils.rs
+++ b/crates/constants/src/chains/test_utils.rs
@@ -1,11 +1,16 @@
 //! Constants for local testnet chains.
 
-use crate::{HostConstants, PredeployTokens, RollupConstants, SignetSystemConstants};
+use crate::{
+    HostConstants, PredeployTokens, RollupConstants, SignetConstants, SignetEnvironmentConstants,
+    SignetSystemConstants,
+};
 use alloy::primitives::{address, Address};
 
 /// Default reward address used in tests when no other is specified.
 pub const DEFAULT_REWARD_ADDRESS: Address = Address::repeat_byte(0x81);
 
+/// Name for the host chain.
+pub const HOST_NAME: &str = "Test Host";
 /// Test chain id for the host chain.
 pub const HOST_CHAIN_ID: u64 = 1;
 /// Test deployment height.
@@ -33,6 +38,8 @@ pub const RU_USDT: Address = address!("0xF34326d3521F1b07d1aa63729cB14A372f8A737
 /// Test address for predeployed WBTC
 pub const RU_WBTC: Address = address!("0xE3d7066115f7d6b65F88Dff86288dB4756a7D733");
 
+/// Name for the network.
+pub const RU_NAME: &str = "Test Rollup";
 /// Test chain id for the RU chain.
 pub const RU_CHAIN_ID: u64 = 15;
 /// Test address for the RU zenith.
@@ -47,6 +54,9 @@ pub const HOST_TOKENS: PredeployTokens = PredeployTokens::new(HOST_USDC, HOST_US
 
 /// RU system tokens.
 pub const RU_TOKENS: PredeployTokens = PredeployTokens::new(RU_USDC, RU_USDT, RU_WBTC);
+
+/// The URL of the Transaction Cache endpoint.
+pub const TX_CACHE_URL: &str = "localhost:8080/txcache";
 
 /// Host config
 pub const HOST: HostConstants = HostConstants::new(
@@ -63,5 +73,15 @@ pub const HOST: HostConstants = HostConstants::new(
 pub const ROLLUP: RollupConstants =
     RollupConstants::new(RU_CHAIN_ID, RU_ORDERS, RU_PASSAGE, BASE_FEE_RECIPIENT, RU_TOKENS);
 
-/// Test constants for unit tests.
-pub const TEST_CONSTANTS: SignetSystemConstants = SignetSystemConstants::new(HOST, ROLLUP);
+/// System constants for unit tests.
+pub const TEST_SYS: SignetSystemConstants = SignetSystemConstants::new(HOST, ROLLUP);
+
+/// Environment constants for unit tests.
+pub const TEST_ENV: SignetEnvironmentConstants = SignetEnvironmentConstants::new(
+    HOST_NAME.to_string(),
+    RU_NAME.to_string(),
+    TX_CACHE_URL.to_string(),
+);
+
+/// Signet constants for Pecorino.
+pub const TEST: SignetConstants = SignetConstants::new(TEST_SYS, TEST_ENV);

--- a/crates/constants/src/lib.rs
+++ b/crates/constants/src/lib.rs
@@ -24,5 +24,5 @@ pub use chains::test_utils;
 mod types;
 pub use types::{
     ConfigError, HostConstants, PairedHeights, PermissionedToken, PredeployTokens, RollupConstants,
-    SignetSystemConstants, MINTER_ADDRESS,
+    SignetConstants, SignetEnvironmentConstants, SignetSystemConstants, MINTER_ADDRESS,
 };

--- a/crates/constants/src/types/environment.rs
+++ b/crates/constants/src/types/environment.rs
@@ -1,0 +1,43 @@
+/// Signet Environment constants.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
+pub struct SignetEnvironmentConstants {
+    /// Name of the host chain.
+    host_name: String,
+    /// Name of the rollup.
+    rollup_name: String,
+    /// URL of the Transaction Cache
+    transaction_cache: String,
+}
+
+impl SignetEnvironmentConstants {
+    /// Create a new set of environment constants.
+    pub const fn new(host_name: String, rollup_name: String, transaction_cache: String) -> Self {
+        Self { host_name, rollup_name, transaction_cache }
+    }
+
+    /// Get the hard-coded pecorino rollup constants.
+    pub const fn pecorino() -> Self {
+        crate::chains::pecorino::PECORINO_ENV
+    }
+
+    /// Get the hard-coded local test rollup constants.
+    #[cfg(any(test, feature = "test-utils"))]
+    pub const fn test() -> Self {
+        crate::chains::test_utils::TEST_ENV
+    }
+
+    /// Get the host name.
+    pub fn host_name(&self) -> &str {
+        &self.host_name
+    }
+
+    /// Get the rollup name.
+    pub fn rollup_name(&self) -> &str {
+        &self.rollup_name
+    }
+
+    /// Get the transaction cache URL.
+    pub fn transaction_cache(&self) -> &str {
+        &self.transaction_cache
+    }
+}

--- a/crates/constants/src/types/environment.rs
+++ b/crates/constants/src/types/environment.rs
@@ -44,9 +44,4 @@ impl SignetEnvironmentConstants {
     pub const fn transaction_cache(&self) -> &str {
         self.transaction_cache
     }
-
-    /// Get the transaction cache URL.
-    pub fn transaction_cache_url(&self) -> reqwest::Url {
-        reqwest::Url::parse(self.transaction_cache).expect("Invalid transaction cache URL")
-    }
 }

--- a/crates/constants/src/types/environment.rs
+++ b/crates/constants/src/types/environment.rs
@@ -1,5 +1,5 @@
 /// Signet Environment constants.
-#[derive(Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
 pub struct SignetEnvironmentConstants {
     /// Name of the host chain.
     host_name: &'static str,
@@ -31,17 +31,17 @@ impl SignetEnvironmentConstants {
     }
 
     /// Get the host name.
-    pub fn host_name(&self) -> &str {
-        &self.host_name
+    pub const fn host_name(&self) -> &str {
+        self.host_name
     }
 
     /// Get the rollup name.
-    pub fn rollup_name(&self) -> &str {
-        &self.rollup_name
+    pub const fn rollup_name(&self) -> &str {
+        self.rollup_name
     }
 
     /// Get the transaction cache URL.
-    pub fn transaction_cache(&self) -> &str {
-        &self.transaction_cache
+    pub const fn transaction_cache(&self) -> &str {
+        self.transaction_cache
     }
 }

--- a/crates/constants/src/types/environment.rs
+++ b/crates/constants/src/types/environment.rs
@@ -44,4 +44,9 @@ impl SignetEnvironmentConstants {
     pub const fn transaction_cache(&self) -> &str {
         self.transaction_cache
     }
+
+    /// Get the transaction cache URL.
+    pub fn transaction_cache_url(&self) -> reqwest::Url {
+        reqwest::Url::parse(self.transaction_cache).expect("Invalid transaction cache URL")
+    }
 }

--- a/crates/constants/src/types/environment.rs
+++ b/crates/constants/src/types/environment.rs
@@ -1,20 +1,22 @@
+use std::borrow::Cow;
+
 /// Signet Environment constants.
-#[derive(Debug, Copy, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
+#[derive(Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
 pub struct SignetEnvironmentConstants {
     /// Name of the host chain.
-    host_name: &'static str,
+    host_name: Cow<'static, str>,
     /// Name of the rollup.
-    rollup_name: &'static str,
+    rollup_name: Cow<'static, str>,
     /// URL of the Transaction Cache
-    transaction_cache: &'static str,
+    transaction_cache: Cow<'static, str>,
 }
 
 impl SignetEnvironmentConstants {
     /// Create a new set of environment constants.
     pub const fn new(
-        host_name: &'static str,
-        rollup_name: &'static str,
-        transaction_cache: &'static str,
+        host_name: Cow<'static, str>,
+        rollup_name: Cow<'static, str>,
+        transaction_cache: Cow<'static, str>,
     ) -> Self {
         Self { host_name, rollup_name, transaction_cache }
     }
@@ -31,17 +33,36 @@ impl SignetEnvironmentConstants {
     }
 
     /// Get the host name.
-    pub const fn host_name(&self) -> &str {
-        self.host_name
+    pub fn host_name(&self) -> &str {
+        self.host_name.as_ref()
     }
 
     /// Get the rollup name.
-    pub const fn rollup_name(&self) -> &str {
-        self.rollup_name
+    pub fn rollup_name(&self) -> &str {
+        self.rollup_name.as_ref()
     }
 
     /// Get the transaction cache URL.
-    pub const fn transaction_cache(&self) -> &str {
-        self.transaction_cache
+    pub fn transaction_cache(&self) -> &str {
+        self.transaction_cache.as_ref()
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn load_built_ins() {
+        // deserialize json
+
+        let json = serde_json::json!({
+            "host_name": "pecorino",
+            "rollup_name": "pecorino",
+            "transaction_cache": "https://pecorino.com"
+        });
+
+        let s = serde_json::from_value::<SignetEnvironmentConstants>(json.clone()).unwrap();
+        assert_eq!(serde_json::to_value(&s).unwrap(), json)
     }
 }

--- a/crates/constants/src/types/environment.rs
+++ b/crates/constants/src/types/environment.rs
@@ -2,16 +2,16 @@
 #[derive(Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
 pub struct SignetEnvironmentConstants {
     /// Name of the host chain.
-    host_name: String,
+    host_name: &'static str,
     /// Name of the rollup.
-    rollup_name: String,
+    rollup_name: &'static str,
     /// URL of the Transaction Cache
-    transaction_cache: String,
+    transaction_cache: &'static str,
 }
 
 impl SignetEnvironmentConstants {
     /// Create a new set of environment constants.
-    pub const fn new(host_name: String, rollup_name: String, transaction_cache: String) -> Self {
+    pub const fn new(host_name: &'static str, rollup_name: &'static str, transaction_cache: &'static str) -> Self {
         Self { host_name, rollup_name, transaction_cache }
     }
 

--- a/crates/constants/src/types/environment.rs
+++ b/crates/constants/src/types/environment.rs
@@ -11,7 +11,11 @@ pub struct SignetEnvironmentConstants {
 
 impl SignetEnvironmentConstants {
     /// Create a new set of environment constants.
-    pub const fn new(host_name: &'static str, rollup_name: &'static str, transaction_cache: &'static str) -> Self {
+    pub const fn new(
+        host_name: &'static str,
+        rollup_name: &'static str,
+        transaction_cache: &'static str,
+    ) -> Self {
         Self { host_name, rollup_name, transaction_cache }
     }
 

--- a/crates/constants/src/types/mod.rs
+++ b/crates/constants/src/types/mod.rs
@@ -13,6 +13,9 @@ pub use rollup::{RollupConstants, MINTER_ADDRESS};
 mod tokens;
 pub use tokens::{PermissionedToken, PredeployTokens};
 
+mod environment;
+pub use environment::SignetEnvironmentConstants;
+
 use alloy::{
     genesis::Genesis,
     primitives::{Address, U256},
@@ -40,13 +43,13 @@ impl SignetSystemConstants {
 
     /// Get the hard-coded pecorino system constants.
     pub const fn pecorino() -> Self {
-        crate::chains::pecorino::PECORINO
+        crate::chains::pecorino::PECORINO_SYS
     }
 
     /// Get the hard-coded local test constants.
     #[cfg(any(test, feature = "test-utils"))]
     pub const fn test() -> Self {
-        crate::chains::test_utils::TEST_CONSTANTS
+        crate::chains::test_utils::TEST_SYS
     }
 
     /// Load the constants from a [`Genesis`].
@@ -207,5 +210,45 @@ impl SignetSystemConstants {
     /// Get the minter address.
     pub const fn minter(&self) -> Address {
         self.rollup.minter()
+    }
+}
+
+/// All constants pertaining to the Signet system.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
+pub struct SignetConstants {
+    /// System constants for a Signet chain.
+    system: SignetSystemConstants,
+    /// Environment constants for a Signet chain.
+    environment: SignetEnvironmentConstants,
+}
+
+impl SignetConstants {
+    /// Create a new set of Signet constants.
+    pub const fn new(
+        system: SignetSystemConstants,
+        environment: SignetEnvironmentConstants,
+    ) -> Self {
+        Self { system, environment }
+    }
+
+    /// Get the hard-coded pecorino rollup constants.
+    pub const fn pecorino() -> Self {
+        crate::chains::pecorino::PECORINO
+    }
+
+    /// Get the hard-coded local test rollup constants.
+    #[cfg(any(test, feature = "test-utils"))]
+    pub const fn test() -> Self {
+        crate::chains::test_utils::TEST
+    }
+
+    /// Get the system constants.
+    pub const fn system(&self) -> &SignetSystemConstants {
+        &self.system
+    }
+
+    /// Get the environment constants.
+    pub const fn environment(&self) -> &SignetEnvironmentConstants {
+        &self.environment
     }
 }

--- a/crates/constants/src/types/mod.rs
+++ b/crates/constants/src/types/mod.rs
@@ -213,9 +213,8 @@ impl SignetSystemConstants {
     }
 }
 
-
 /// All constants pertaining to the Signet system.
-#[derive(Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SignetConstants {
     /// System constants for a Signet chain.
     system: SignetSystemConstants,

--- a/crates/constants/src/types/mod.rs
+++ b/crates/constants/src/types/mod.rs
@@ -213,6 +213,7 @@ impl SignetSystemConstants {
     }
 }
 
+
 /// All constants pertaining to the Signet system.
 #[derive(Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
 pub struct SignetConstants {

--- a/crates/constants/src/types/mod.rs
+++ b/crates/constants/src/types/mod.rs
@@ -258,7 +258,7 @@ impl SignetConstants {
     }
 
     /// Get the environment constants.
-    pub const fn environment(&self) -> SignetEnvironmentConstants {
-        self.environment
+    pub const fn environment(&self) -> &SignetEnvironmentConstants {
+        &self.environment
     }
 }

--- a/crates/constants/src/types/mod.rs
+++ b/crates/constants/src/types/mod.rs
@@ -243,12 +243,22 @@ impl SignetConstants {
     }
 
     /// Get the system constants.
-    pub const fn system(&self) -> &SignetSystemConstants {
-        &self.system
+    pub const fn system(&self) -> SignetSystemConstants {
+        self.system
+    }
+
+    /// Get the host constants.
+    pub const fn host(&self) -> HostConstants {
+        self.system.host
+    }
+
+    /// Get the rollup constants.
+    pub const fn rollup(&self) -> RollupConstants {
+        self.system.rollup
     }
 
     /// Get the environment constants.
-    pub const fn environment(&self) -> &SignetEnvironmentConstants {
-        &self.environment
+    pub const fn environment(&self) -> SignetEnvironmentConstants {
+        self.environment
     }
 }

--- a/crates/evm/src/lib.rs
+++ b/crates/evm/src/lib.rs
@@ -88,7 +88,7 @@ pub mod test_utils {
     /// Create a new Signet EVM with an in-memory database for testing.
     pub fn test_signet_evm() -> super::EvmNeedsBlock<trevm::revm::database::in_memory_db::InMemoryDB>
     {
-        super::signet_evm(InMemoryDB::default(), TEST_CONSTANTS).fill_cfg(&TestCfg)
+        super::signet_evm(InMemoryDB::default(), TEST_SYS).fill_cfg(&TestCfg)
     }
 
     /// Test configuration for the Signet EVM.

--- a/crates/evm/src/lib.rs
+++ b/crates/evm/src/lib.rs
@@ -81,6 +81,7 @@ where
 /// Test utilities for the Signet EVM impl.
 #[cfg(any(test, feature = "test-utils"))]
 pub mod test_utils {
+    use crate::signet_evm;
     use reth::revm::{context::CfgEnv, primitives::hardfork::SpecId};
     use signet_types::test_utils::*;
     use trevm::revm::database::in_memory_db::InMemoryDB;
@@ -88,7 +89,7 @@ pub mod test_utils {
     /// Create a new Signet EVM with an in-memory database for testing.
     pub fn test_signet_evm() -> super::EvmNeedsBlock<trevm::revm::database::in_memory_db::InMemoryDB>
     {
-        super::signet_evm(InMemoryDB::default(), TEST_SYS).fill_cfg(&TestCfg)
+        signet_evm(InMemoryDB::default(), TEST_SYS).fill_cfg(&TestCfg)
     }
 
     /// Test configuration for the Signet EVM.

--- a/crates/extract/src/extractor.rs
+++ b/crates/extract/src/extractor.rs
@@ -177,7 +177,7 @@ mod test {
             .submit_block(ru_block);
         let (chain, _) = hbs.to_chain();
 
-        let extractor = Extractor::new(TEST_CONSTANTS);
+        let extractor = Extractor::new(TEST_SYS);
         let extracts = extractor.extract_signet(&chain).next().unwrap();
 
         hbs.assert_conforms(&extracts);

--- a/crates/rpc/examples/filler.rs
+++ b/crates/rpc/examples/filler.rs
@@ -61,7 +61,7 @@ where
         Ok(Self {
             signer,
             ru_provider,
-            tx_cache: TxCache::new_from_string(&constants.environment().transaction_cache())?,
+            tx_cache: TxCache::new_from_string(constants.environment().transaction_cache())?,
             constants,
         })
     }

--- a/crates/rpc/examples/filler.rs
+++ b/crates/rpc/examples/filler.rs
@@ -53,8 +53,17 @@ where
     S: Signer,
 {
     /// Create a new Filler with the given signer, provider, and transaction cache endpoint.
-    pub fn new(signer: S, ru_provider: Provider, constants: SignetConstants) -> Self {
-        Self { signer, ru_provider, tx_cache: TxCache::from(&constants), constants }
+    pub fn new(
+        signer: S,
+        ru_provider: Provider,
+        constants: SignetConstants,
+    ) -> Result<Self, Error> {
+        Ok(Self {
+            signer,
+            ru_provider,
+            tx_cache: TxCache::from_environment(&constants.environment())?,
+            constants,
+        })
     }
 
     /// Query the transaction cache to get all possible orders.

--- a/crates/rpc/examples/filler.rs
+++ b/crates/rpc/examples/filler.rs
@@ -14,7 +14,7 @@ use alloy::{
 };
 use eyre::{eyre, Error};
 use signet_bundle::SignetEthBundle;
-use signet_constants::SignetSystemConstants;
+use signet_constants::SignetConstants;
 use signet_tx_cache::{client::TxCache, types::TxCacheSendBundleResponse};
 use signet_types::{AggregateOrders, SignedFill, SignedOrder, UnsignedFill};
 use std::{collections::HashMap, slice::from_ref};
@@ -45,7 +45,7 @@ pub struct Filler<S: Signer> {
     /// The transaction cache endpoint.
     tx_cache: TxCache,
     /// The system constants.
-    constants: SignetSystemConstants,
+    constants: SignetConstants,
 }
 
 impl<S> Filler<S>
@@ -53,13 +53,8 @@ where
     S: Signer,
 {
     /// Create a new Filler with the given signer, provider, and transaction cache endpoint.
-    pub const fn new(
-        signer: S,
-        ru_provider: Provider,
-        tx_cache: TxCache,
-        constants: SignetSystemConstants,
-    ) -> Self {
-        Self { signer, ru_provider, tx_cache, constants }
+    pub fn new(signer: S, ru_provider: Provider, constants: SignetConstants) -> Self {
+        Self { signer, ru_provider, tx_cache: TxCache::from(&constants), constants }
     }
 
     /// Query the transaction cache to get all possible orders.
@@ -159,6 +154,7 @@ where
             unsigned_fill = unsigned_fill.with_chain(
                 chain_id,
                 self.constants
+                    .system()
                     .orders_for(chain_id)
                     .ok_or(eyre!("invalid target chain id {}", chain_id))?,
             );

--- a/crates/rpc/examples/filler.rs
+++ b/crates/rpc/examples/filler.rs
@@ -61,7 +61,7 @@ where
         Ok(Self {
             signer,
             ru_provider,
-            tx_cache: TxCache::from_environment(&constants.environment())?,
+            tx_cache: TxCache::new_from_string(&constants.environment().transaction_cache())?,
             constants,
         })
     }

--- a/crates/rpc/examples/order.rs
+++ b/crates/rpc/examples/order.rs
@@ -30,7 +30,7 @@ where
     pub fn new(signer: S, constants: SignetConstants) -> Result<Self, Error> {
         Ok(Self {
             signer,
-            tx_cache: TxCache::new_from_string(&constants.environment().transaction_cache())?,
+            tx_cache: TxCache::new_from_string(constants.environment().transaction_cache())?,
             constants,
         })
     }

--- a/crates/rpc/examples/order.rs
+++ b/crates/rpc/examples/order.rs
@@ -27,8 +27,12 @@ where
     S: Signer,
 {
     /// Create a new SendOrder instance.
-    pub fn new(signer: S, constants: SignetConstants) -> Self {
-        Self { signer, tx_cache: TxCache::from(&constants), constants }
+    pub fn new(signer: S, constants: SignetConstants) -> Result<Self, Error> {
+        Ok(Self {
+            signer,
+            tx_cache: TxCache::from_environment(&constants.environment())?,
+            constants,
+        })
     }
 
     /// Construct a simple example Order, sign it, and send it.

--- a/crates/rpc/examples/order.rs
+++ b/crates/rpc/examples/order.rs
@@ -4,7 +4,7 @@ use alloy::{
 };
 use chrono::Utc;
 use eyre::Error;
-use signet_constants::{SignetConstants, SignetSystemConstants};
+use signet_constants::SignetConstants;
 use signet_tx_cache::client::TxCache;
 use signet_types::UnsignedOrder;
 use signet_zenith::RollupOrders::{Input, Order, Output};

--- a/crates/rpc/examples/order.rs
+++ b/crates/rpc/examples/order.rs
@@ -30,7 +30,7 @@ where
     pub fn new(signer: S, constants: SignetConstants) -> Result<Self, Error> {
         Ok(Self {
             signer,
-            tx_cache: TxCache::from_environment(&constants.environment())?,
+            tx_cache: TxCache::new_from_string(&constants.environment().transaction_cache())?,
             constants,
         })
     }

--- a/crates/rpc/examples/order.rs
+++ b/crates/rpc/examples/order.rs
@@ -4,7 +4,7 @@ use alloy::{
 };
 use chrono::Utc;
 use eyre::Error;
-use signet_constants::SignetSystemConstants;
+use signet_constants::{SignetConstants, SignetSystemConstants};
 use signet_tx_cache::client::TxCache;
 use signet_types::UnsignedOrder;
 use signet_zenith::RollupOrders::{Input, Order, Output};
@@ -19,7 +19,7 @@ pub struct SendOrder<S: Signer> {
     /// The transaction cache endpoint.
     tx_cache: TxCache,
     /// The system constants.
-    constants: SignetSystemConstants,
+    constants: SignetConstants,
 }
 
 impl<S> SendOrder<S>
@@ -27,8 +27,8 @@ where
     S: Signer,
 {
     /// Create a new SendOrder instance.
-    pub const fn new(signer: S, tx_cache: TxCache, constants: SignetSystemConstants) -> Self {
-        Self { signer, tx_cache, constants }
+    pub fn new(signer: S, constants: SignetConstants) -> Self {
+        Self { signer, tx_cache: TxCache::from(&constants), constants }
     }
 
     /// Construct a simple example Order, sign it, and send it.

--- a/crates/sim/tests/basic_sim.rs
+++ b/crates/sim/tests/basic_sim.rs
@@ -58,7 +58,7 @@ pub async fn test_simulator() {
     // Set up the simulator
     let built = BlockBuild::<_, NoOpInspector>::new(
         db,
-        TEST_CONSTANTS,
+        TEST_SYS,
         TestCfg,
         NoopBlock,
         std::time::Instant::now() + std::time::Duration::from_millis(200),

--- a/crates/tx-cache/Cargo.toml
+++ b/crates/tx-cache/Cargo.toml
@@ -13,11 +13,7 @@ repository.workspace = true
 [dependencies]
 signet-bundle.workspace = true
 signet-types.workspace = true
-signet-zenith.workspace = true
 signet-constants.workspace = true
-
-ajj.workspace = true
-trevm.workspace = true
 
 alloy.workspace = true
 

--- a/crates/tx-cache/Cargo.toml
+++ b/crates/tx-cache/Cargo.toml
@@ -13,6 +13,11 @@ repository.workspace = true
 [dependencies]
 signet-bundle.workspace = true
 signet-types.workspace = true
+signet-zenith.workspace = true
+signet-constants.workspace = true
+
+ajj.workspace = true
+trevm.workspace = true
 
 alloy.workspace = true
 

--- a/crates/tx-cache/src/client.rs
+++ b/crates/tx-cache/src/client.rs
@@ -6,6 +6,7 @@ use alloy::consensus::TxEnvelope;
 use eyre::Error;
 use serde::{de::DeserializeOwned, Serialize};
 use signet_bundle::SignetEthBundle;
+use signet_constants::SignetEnvironmentConstants;
 use signet_types::SignedOrder;
 use tracing::{instrument, warn};
 
@@ -33,6 +34,19 @@ impl TxCache {
     /// Instantiate a new cache with the given URL and a new reqwest client.
     pub fn new(url: reqwest::Url) -> Self {
         Self { url, client: reqwest::Client::new() }
+    }
+
+    /// Create a new cache for Pecorino.
+    pub fn pecorino() -> Self {
+        SignetEnvironmentConstants::pecorino().into()
+    }
+
+    /// Create a new cache for Pecorino and client.
+    pub fn pecorino_with_client(client: reqwest::Client) -> Self {
+        Self::new_with_client(
+            SignetEnvironmentConstants::pecorino().transaction_cache_url(),
+            client,
+        )
     }
 
     async fn forward_inner<T: Serialize + Send, R: DeserializeOwned>(
@@ -134,5 +148,12 @@ impl TxCache {
         let response: TxCacheOrdersResponse =
             self.get_inner::<TxCacheOrdersResponse>(ORDERS).await?;
         Ok(response.orders)
+    }
+}
+
+// implement a From trait for TxCache from SignetEnvironmentConstants
+impl From<SignetEnvironmentConstants> for TxCache {
+    fn from(constants: SignetEnvironmentConstants) -> Self {
+        Self::new(constants.transaction_cache_url())
     }
 }

--- a/crates/tx-cache/src/client.rs
+++ b/crates/tx-cache/src/client.rs
@@ -6,7 +6,7 @@ use alloy::consensus::TxEnvelope;
 use eyre::Error;
 use serde::{de::DeserializeOwned, Serialize};
 use signet_bundle::SignetEthBundle;
-use signet_constants::SignetEnvironmentConstants;
+use signet_constants::{SignetConstants, SignetEnvironmentConstants};
 use signet_types::SignedOrder;
 use tracing::{instrument, warn};
 
@@ -38,7 +38,7 @@ impl TxCache {
 
     /// Create a new cache for Pecorino.
     pub fn pecorino() -> Self {
-        SignetEnvironmentConstants::pecorino().into()
+        (&SignetEnvironmentConstants::pecorino()).into()
     }
 
     /// Create a new cache for Pecorino and client.
@@ -152,8 +152,15 @@ impl TxCache {
 }
 
 // implement a From trait for TxCache from SignetEnvironmentConstants
-impl From<SignetEnvironmentConstants> for TxCache {
-    fn from(constants: SignetEnvironmentConstants) -> Self {
+impl From<&SignetEnvironmentConstants> for TxCache {
+    fn from(constants: &SignetEnvironmentConstants) -> Self {
         Self::new(constants.transaction_cache_url())
+    }
+}
+
+// implement a From trait for TxCache from SignetConstants
+impl From<&SignetConstants> for TxCache {
+    fn from(constants: &SignetConstants) -> Self {
+        Self::new(constants.environment().transaction_cache_url())
     }
 }

--- a/crates/tx-cache/src/client.rs
+++ b/crates/tx-cache/src/client.rs
@@ -6,7 +6,7 @@ use alloy::consensus::TxEnvelope;
 use eyre::Error;
 use serde::{de::DeserializeOwned, Serialize};
 use signet_bundle::SignetEthBundle;
-use signet_constants::{pecorino, SignetEnvironmentConstants};
+use signet_constants::pecorino;
 use signet_types::SignedOrder;
 use tracing::{instrument, warn};
 
@@ -36,6 +36,12 @@ impl TxCache {
         Self { url, client: reqwest::Client::new() }
     }
 
+    /// Create a new cache given a string (not URL).
+    pub fn new_from_string(url: &str) -> Result<Self, Error> {
+        let url = reqwest::Url::parse(url)?;
+        Ok(Self::new(url))
+    }
+
     /// Create a new cache for Pecorino.
     pub fn pecorino() -> Self {
         let url =
@@ -48,21 +54,6 @@ impl TxCache {
         let url =
             reqwest::Url::parse(pecorino::TX_CACHE_URL).expect("pecorino tx cache URL invalid");
         Self::new_with_client(url, client)
-    }
-
-    /// Create a new cache for a given SignetEnvironmentConstants.
-    pub fn from_environment(env: &SignetEnvironmentConstants) -> Result<Self, Error> {
-        let url = reqwest::Url::parse(env.transaction_cache())?;
-        Ok(Self::new(url))
-    }
-
-    /// Create a new cache for a given SignetEnvironmentConstants and client.
-    pub fn from_environment_with_client(
-        env: &SignetEnvironmentConstants,
-        client: reqwest::Client,
-    ) -> Result<Self, Error> {
-        let url = reqwest::Url::parse(env.transaction_cache())?;
-        Ok(Self::new_with_client(url, client))
     }
 
     async fn forward_inner<T: Serialize + Send, R: DeserializeOwned>(

--- a/crates/tx-cache/src/client.rs
+++ b/crates/tx-cache/src/client.rs
@@ -36,18 +36,18 @@ impl TxCache {
         Self { url, client: reqwest::Client::new() }
     }
 
-    /// Create a new cache given a string (not URL).
+    /// Create a new cache given a string URL.
     pub fn new_from_string(url: &str) -> Result<Self, Error> {
         let url = reqwest::Url::parse(url)?;
         Ok(Self::new(url))
     }
 
-    /// Create a new cache for Pecorino.
+    /// Connect to the Pecorino tx cache.
     pub fn pecorino() -> Self {
         Self::new_from_string(pecorino::TX_CACHE_URL).expect("pecorino tx cache URL invalid")
     }
 
-    /// Create a new cache for Pecorino and client.
+    /// Connect to the Pecornio tx cache, using a specific [`Client`].
     pub fn pecorino_with_client(client: reqwest::Client) -> Self {
         let url =
             reqwest::Url::parse(pecorino::TX_CACHE_URL).expect("pecorino tx cache URL invalid");

--- a/crates/tx-cache/src/client.rs
+++ b/crates/tx-cache/src/client.rs
@@ -44,9 +44,7 @@ impl TxCache {
 
     /// Create a new cache for Pecorino.
     pub fn pecorino() -> Self {
-        let url =
-            reqwest::Url::parse(pecorino::TX_CACHE_URL).expect("pecorino tx cache URL invalid");
-        Self::new(url)
+        Self::new_from_string(pecorino::TX_CACHE_URL).expect("pecorino tx cache URL invalid")
     }
 
     /// Create a new cache for Pecorino and client.


### PR DESCRIPTION
- add `SignetEnvironmentConstants` and `SignetConstants` (system + environment)
   - contains names for Host and Rollup networks & the Transaction Cache URL
- adds `TxCache::pecorino()` and `TxCache::pecorino_with_client(client: Client)`
- updates Filler and Order example code to use new constants