### PR TITLE
feat(rpc): stub tracing methods

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,6 +77,9 @@ reth-prune-types = { git = "https://github.com/paradigmxyz/reth", tag = "v1.3.4"
 reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", tag = "v1.3.4" }
 reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", tag = "v1.3.4" }
 reth-trie-db = { git = "https://github.com/paradigmxyz/reth", tag = "v1.3.4" }
+# adjacent reth revm inspectors
+revm-inspectors = "0.17.0-alpha.1"
+
 
 # Foundry periphery
 foundry-blob-explorers = "0.10"

--- a/crates/rpc/Cargo.toml
+++ b/crates/rpc/Cargo.toml
@@ -23,6 +23,7 @@ reth-chainspec.workspace = true
 reth-evm-ethereum.workspace = true
 reth-node-api.workspace = true
 reth-rpc-eth-api.workspace = true
+revm-inspectors.workspace = true
 
 axum = "0.8.1"
 dashmap = "6.1.0"

--- a/crates/rpc/src/debug/endpoints.rs
+++ b/crates/rpc/src/debug/endpoints.rs
@@ -1,7 +1,12 @@
 use crate::{Pnt, RpcCtx};
+use ajj::HandlerCtx;
+use alloy::{eips::BlockNumberOrTag, primitives::B256};
+use reth::rpc::types::trace::geth::GethDebugTracingOptions;
 use reth_node_api::FullNodeComponents;
 
 pub(super) async fn trace_transaction<Host, Signet>(
+    _hctx: HandlerCtx,
+    (_tx_hash, _opts): (B256, GethDebugTracingOptions),
     _ctx: RpcCtx<Host, Signet>,
 ) -> Result<(), String>
 where
@@ -12,6 +17,8 @@ where
 }
 
 pub(super) async fn trace_block_by_number<Host, Signet>(
+    _hctx: HandlerCtx,
+    (_block, _opts): (BlockNumberOrTag, Option<GethDebugTracingOptions>),
     _ctx: RpcCtx<Host, Signet>,
 ) -> Result<(), String>
 where

--- a/crates/rpc/src/debug/endpoints.rs
+++ b/crates/rpc/src/debug/endpoints.rs
@@ -1,0 +1,22 @@
+use crate::{Pnt, RpcCtx};
+use reth_node_api::FullNodeComponents;
+
+pub(super) async fn trace_transaction<Host, Signet>(
+    _ctx: RpcCtx<Host, Signet>,
+) -> Result<(), String>
+where
+    Host: FullNodeComponents,
+    Signet: Pnt,
+{
+    Ok(())
+}
+
+pub(super) async fn trace_block_by_number<Host, Signet>(
+    _ctx: RpcCtx<Host, Signet>,
+) -> Result<(), String>
+where
+    Host: FullNodeComponents,
+    Signet: Pnt,
+{
+    Ok(())
+}

--- a/crates/rpc/src/debug/mod.rs
+++ b/crates/rpc/src/debug/mod.rs
@@ -1,0 +1,16 @@
+mod endpoints;
+use endpoints::*;
+use reth_node_api::FullNodeComponents;
+
+use crate::{Pnt, RpcCtx};
+
+/// Instantiate the debug router.
+pub fn debug<Host, Signet>() -> ajj::Router<RpcCtx<Host, Signet>>
+where
+    Host: FullNodeComponents,
+    Signet: Pnt,
+{
+    ajj::Router::new()
+        .route("traceTransaction", trace_transaction)
+        .route("traceBlockByNumber", trace_block_by_number)
+}

--- a/crates/rpc/src/lib.rs
+++ b/crates/rpc/src/lib.rs
@@ -60,6 +60,12 @@ pub use eth::{eth, CallErrorData, EthError};
 mod signet;
 pub use signet::{error::SignetError, signet};
 
+mod debug;
+pub use debug::debug;
+
+mod trace;
+pub use trace::trace;
+
 mod interest;
 
 pub mod receipts;
@@ -80,5 +86,9 @@ where
     Host: FullNodeComponents,
     Signet: Pnt,
 {
-    ajj::Router::new().nest("eth", eth::<Host, Signet>()).nest("signet", signet::<Host, Signet>())
+    ajj::Router::new()
+        .nest("eth", eth::<Host, Signet>())
+        .nest("signet", signet::<Host, Signet>())
+        .nest("debug", debug::<Host, Signet>())
+        .nest("trace", trace::<Host, Signet>())
 }

--- a/crates/rpc/src/trace/endpoints.rs
+++ b/crates/rpc/src/trace/endpoints.rs
@@ -1,7 +1,14 @@
 use crate::{Pnt, RpcCtx};
+use ajj::HandlerCtx;
+use alloy::{eips::BlockId, primitives::map::foldhash::HashSet};
+use reth::rpc::types::trace::parity::TraceType;
 use reth_node_api::FullNodeComponents;
 
-pub(super) async fn trace_block<Host, Signet>(_ctx: RpcCtx<Host, Signet>) -> Result<(), String>
+pub(super) async fn trace_block<Host, Signet>(
+    _hctx: HandlerCtx,
+    _block_id: BlockId,
+    _ctx: RpcCtx<Host, Signet>,
+) -> Result<(), String>
 where
     Host: FullNodeComponents,
     Signet: Pnt,
@@ -10,6 +17,8 @@ where
 }
 
 pub(super) async fn trace_replay_block_transactions<Host, Signet>(
+    _hctx: HandlerCtx,
+    (_block_id, _trace_types): (BlockId, HashSet<TraceType>),
     _ctx: RpcCtx<Host, Signet>,
 ) -> Result<(), String>
 where

--- a/crates/rpc/src/trace/endpoints.rs
+++ b/crates/rpc/src/trace/endpoints.rs
@@ -1,0 +1,20 @@
+use crate::{Pnt, RpcCtx};
+use reth_node_api::FullNodeComponents;
+
+pub(super) async fn trace_block<Host, Signet>(_ctx: RpcCtx<Host, Signet>) -> Result<(), String>
+where
+    Host: FullNodeComponents,
+    Signet: Pnt,
+{
+    Ok(())
+}
+
+pub(super) async fn trace_replay_block_transactions<Host, Signet>(
+    _ctx: RpcCtx<Host, Signet>,
+) -> Result<(), String>
+where
+    Host: FullNodeComponents,
+    Signet: Pnt,
+{
+    Ok(())
+}

--- a/crates/rpc/src/trace/mod.rs
+++ b/crates/rpc/src/trace/mod.rs
@@ -1,0 +1,16 @@
+mod endpoints;
+use endpoints::*;
+
+use crate::{ctx::RpcCtx, Pnt};
+use reth_node_api::FullNodeComponents;
+
+/// Instantiate the `trace` API router.
+pub fn trace<Host, Signet>() -> ajj::Router<RpcCtx<Host, Signet>>
+where
+    Host: FullNodeComponents,
+    Signet: Pnt,
+{
+    ajj::Router::new()
+        .route("block", trace_block)
+        .route("replayBlockTransactions", trace_replay_block_transactions)
+}


### PR DESCRIPTION
Adds the methods / file structure for implementing the tracing methods needed for blockscout.

Closes ENG-1066
Closes ENG-1067