### PR TITLE
fix(ci): handle new clippy lints

### DIFF
--- a/clippy.toml
+++ b/clippy.toml
@@ -1,1 +1,2 @@
 too-large-for-stack = 128
+large-error-threshold = 256

--- a/crates/rpc/src/interest/subs.rs
+++ b/crates/rpc/src/interest/subs.rs
@@ -24,8 +24,8 @@ use tracing::{debug, debug_span, enabled, trace, Instrument};
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
 #[serde(untagged)]
 pub enum Either {
-    Log(Log),
-    Block(Header),
+    Log(Box<Log>),
+    Block(Box<Header>),
 }
 
 /// Buffer for subscription outputs.
@@ -65,8 +65,8 @@ impl SubscriptionBuffer {
     /// Pop the front of the buffer.
     pub fn pop_front(&mut self) -> Option<Either> {
         match self {
-            Self::Log(buf) => buf.pop_front().map(Either::Log),
-            Self::Block(buf) => buf.pop_front().map(Either::Block),
+            Self::Log(buf) => buf.pop_front().map(|log| Either::Log(Box::new(log))),
+            Self::Block(buf) => buf.pop_front().map(|header| Either::Block(Box::new(header))),
         }
     }
 }


### PR DESCRIPTION
Closes ENG-1086

We'll ignore a large error warning by just bumping the size. it's barely above the threshold and non-consequential.

For the large enum variant lint, we now box logs/headers when outputting them from the subscription buffer.