### PR TITLE
feat: impl FromStr for chain constants

### DIFF
--- a/crates/constants/src/lib.rs
+++ b/crates/constants/src/lib.rs
@@ -23,7 +23,7 @@ pub use chains::test_utils;
 
 mod types;
 pub use types::{
-    ConfigError, HostConstants, PairedHeights, ParseChainError, PermissionedToken, PredeployTokens,
-    RollupConstants, SignetConstants, SignetEnvironmentConstants, SignetSystemConstants,
-    MINTER_ADDRESS,
+    ConfigError, HostConstants, KnownChains, PairedHeights, ParseChainError, PermissionedToken,
+    PredeployTokens, RollupConstants, SignetConstants, SignetEnvironmentConstants,
+    SignetSystemConstants, MINTER_ADDRESS,
 };

--- a/crates/constants/src/lib.rs
+++ b/crates/constants/src/lib.rs
@@ -23,6 +23,7 @@ pub use chains::test_utils;
 
 mod types;
 pub use types::{
-    ConfigError, HostConstants, PairedHeights, PermissionedToken, PredeployTokens, RollupConstants,
-    SignetConstants, SignetEnvironmentConstants, SignetSystemConstants, MINTER_ADDRESS,
+    ConfigError, HostConstants, PairedHeights, ParseChainError, PermissionedToken, PredeployTokens,
+    RollupConstants, SignetConstants, SignetEnvironmentConstants, SignetSystemConstants,
+    MINTER_ADDRESS,
 };

--- a/crates/constants/src/types/chains.rs
+++ b/crates/constants/src/types/chains.rs
@@ -1,5 +1,8 @@
 use std::str::FromStr;
 
+/// The list of known chains as a string.
+const KNOWN_CHAINS: &str = "pecorino, test";
+
 /// Error type for parsing struct from a chain name.
 #[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
 pub enum ParseChainError {
@@ -7,9 +10,6 @@ pub enum ParseChainError {
     #[error("chain name {0} is not parseable. supported chains: {KNOWN_CHAINS}")]
     ChainNotSupported(String),
 }
-
-/// The list of known chains as a string.
-const KNOWN_CHAINS: &str = "pecorino, test";
 
 /// Known chains for the Signet system.
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]

--- a/crates/constants/src/types/chains.rs
+++ b/crates/constants/src/types/chains.rs
@@ -1,0 +1,36 @@
+use std::str::FromStr;
+
+/// Error type for parsing struct from a chain name.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum ParseChainError {
+    /// The chain name is not supported.
+    #[error("chain name {0} is not parseable. supported chains: {KNOWN_CHAINS}")]
+    ChainNotSupported(String),
+}
+
+/// The list of known chains as a string.
+const KNOWN_CHAINS: &str = "pecorino, test";
+
+/// Known chains for the Signet system.
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub enum KnownChains {
+    /// Pecorino chain.
+    Pecorino,
+    /// Test chain.
+    #[cfg(any(test, feature = "test-utils"))]
+    Test,
+}
+
+impl FromStr for KnownChains {
+    type Err = ParseChainError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let s = s.trim().to_lowercase();
+        match s.as_str() {
+            "pecorino" => Ok(Self::Pecorino),
+            #[cfg(any(test, feature = "test-utils"))]
+            "test" => Ok(Self::Test),
+            _ => Err(ParseChainError::ChainNotSupported(s)),
+        }
+    }
+}

--- a/crates/constants/src/types/environment.rs
+++ b/crates/constants/src/types/environment.rs
@@ -1,3 +1,4 @@
+use crate::{KnownChains, ParseChainError};
 use std::{borrow::Cow, str::FromStr};
 
 /// Signet Environment constants.
@@ -48,24 +49,15 @@ impl SignetEnvironmentConstants {
     }
 }
 
-/// Error type for parsing struct from a chain name.
-#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
-pub enum ParseChainError {
-    /// The chain name is not supported.
-    #[error("chain name {0} is not parseable. supported chains: {1}")]
-    ChainNotSupported(String, String),
-}
-
 impl FromStr for SignetEnvironmentConstants {
     type Err = ParseChainError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let s = s.trim().to_lowercase();
-        match s.as_str() {
-            "pecorino" => Ok(Self::pecorino()),
+        let chain: KnownChains = s.parse()?;
+        match chain {
+            KnownChains::Pecorino => Ok(Self::pecorino()),
             #[cfg(any(test, feature = "test-utils"))]
-            "test" => Ok(Self::test()),
-            _ => Err(ParseChainError::ChainNotSupported(s, "pecorino, test".to_string())),
+            KnownChains::Test => Ok(Self::test()),
         }
     }
 }

--- a/crates/constants/src/types/environment.rs
+++ b/crates/constants/src/types/environment.rs
@@ -1,4 +1,4 @@
-use std::borrow::Cow;
+use std::{borrow::Cow, str::FromStr};
 
 /// Signet Environment constants.
 #[derive(Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
@@ -45,6 +45,28 @@ impl SignetEnvironmentConstants {
     /// Get the transaction cache URL.
     pub fn transaction_cache(&self) -> &str {
         self.transaction_cache.as_ref()
+    }
+}
+
+/// Error type for parsing struct from a chain name.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum ParseChainError {
+    /// The chain name is not supported.
+    #[error("chain name {0} is not parseable. supported chains: {1}")]
+    ChainNotSupported(String, String),
+}
+
+impl FromStr for SignetEnvironmentConstants {
+    type Err = ParseChainError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let s = s.trim().to_lowercase();
+        match s.as_str() {
+            "pecorino" => Ok(Self::pecorino()),
+            #[cfg(any(test, feature = "test-utils"))]
+            "test" => Ok(Self::test()),
+            _ => Err(ParseChainError::ChainNotSupported(s, "pecorino, test".to_string())),
+        }
     }
 }
 

--- a/crates/constants/src/types/host.rs
+++ b/crates/constants/src/types/host.rs
@@ -1,4 +1,4 @@
-use crate::types::{ConfigError, ParseChainError, PredeployTokens};
+use crate::types::{ConfigError, KnownChains, ParseChainError, PredeployTokens};
 use alloy::{genesis::Genesis, primitives::Address};
 use serde_json::Value;
 use std::str::FromStr;
@@ -130,12 +130,11 @@ impl FromStr for HostConstants {
     type Err = ParseChainError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let s = s.trim().to_lowercase();
-        match s.as_str() {
-            "pecorino" => Ok(Self::pecorino()),
+        let chain: KnownChains = s.parse()?;
+        match chain {
+            KnownChains::Pecorino => Ok(Self::pecorino()),
             #[cfg(any(test, feature = "test-utils"))]
-            "test" => Ok(Self::test()),
-            _ => Err(ParseChainError::ChainNotSupported(s, "pecorino, test".to_string())),
+            KnownChains::Test => Ok(Self::test()),
         }
     }
 }

--- a/crates/constants/src/types/host.rs
+++ b/crates/constants/src/types/host.rs
@@ -1,6 +1,7 @@
-use crate::types::{ConfigError, PredeployTokens};
+use crate::types::{ConfigError, ParseChainError, PredeployTokens};
 use alloy::{genesis::Genesis, primitives::Address};
 use serde_json::Value;
+use std::str::FromStr;
 
 /// System addresses and other configuration details on the host chain.
 ///
@@ -122,5 +123,19 @@ impl HostConstants {
     /// Get the host tokens.
     pub const fn tokens(&self) -> PredeployTokens {
         self.tokens
+    }
+}
+
+impl FromStr for HostConstants {
+    type Err = ParseChainError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let s = s.trim().to_lowercase();
+        match s.as_str() {
+            "pecorino" => Ok(Self::pecorino()),
+            #[cfg(any(test, feature = "test-utils"))]
+            "test" => Ok(Self::test()),
+            _ => Err(ParseChainError::ChainNotSupported(s, "pecorino, test".to_string())),
+        }
     }
 }

--- a/crates/constants/src/types/mod.rs
+++ b/crates/constants/src/types/mod.rs
@@ -10,11 +10,14 @@ pub use host::HostConstants;
 mod rollup;
 pub use rollup::{RollupConstants, MINTER_ADDRESS};
 
+mod chains;
+pub use chains::{KnownChains, ParseChainError};
+
 mod tokens;
 pub use tokens::{PermissionedToken, PredeployTokens};
 
 mod environment;
-pub use environment::{ParseChainError, SignetEnvironmentConstants};
+pub use environment::SignetEnvironmentConstants;
 
 use alloy::{
     genesis::Genesis,
@@ -218,12 +221,11 @@ impl FromStr for SignetSystemConstants {
     type Err = ParseChainError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let s = s.trim().to_lowercase();
-        match s.as_str() {
-            "pecorino" => Ok(Self::pecorino()),
+        let chain: KnownChains = s.parse()?;
+        match chain {
+            KnownChains::Pecorino => Ok(Self::pecorino()),
             #[cfg(any(test, feature = "test-utils"))]
-            "test" => Ok(Self::test()),
-            _ => Err(ParseChainError::ChainNotSupported(s, "pecorino, test".to_string())),
+            KnownChains::Test => Ok(Self::test()),
         }
     }
 }
@@ -282,12 +284,11 @@ impl FromStr for SignetConstants {
     type Err = ParseChainError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let s = s.trim().to_lowercase();
-        match s.as_str() {
-            "pecorino" => Ok(Self::pecorino()),
+        let chain: KnownChains = s.parse()?;
+        match chain {
+            KnownChains::Pecorino => Ok(Self::pecorino()),
             #[cfg(any(test, feature = "test-utils"))]
-            "test" => Ok(Self::test()),
-            _ => Err(ParseChainError::ChainNotSupported(s, "pecorino, test".to_string())),
+            KnownChains::Test => Ok(Self::test()),
         }
     }
 }

--- a/crates/constants/src/types/mod.rs
+++ b/crates/constants/src/types/mod.rs
@@ -14,12 +14,13 @@ mod tokens;
 pub use tokens::{PermissionedToken, PredeployTokens};
 
 mod environment;
-pub use environment::SignetEnvironmentConstants;
+pub use environment::{ParseChainError, SignetEnvironmentConstants};
 
 use alloy::{
     genesis::Genesis,
     primitives::{Address, U256},
 };
+use std::str::FromStr;
 
 /// Signet constants.
 ///
@@ -213,6 +214,20 @@ impl SignetSystemConstants {
     }
 }
 
+impl FromStr for SignetSystemConstants {
+    type Err = ParseChainError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let s = s.trim().to_lowercase();
+        match s.as_str() {
+            "pecorino" => Ok(Self::pecorino()),
+            #[cfg(any(test, feature = "test-utils"))]
+            "test" => Ok(Self::test()),
+            _ => Err(ParseChainError::ChainNotSupported(s, "pecorino, test".to_string())),
+        }
+    }
+}
+
 /// All constants pertaining to the Signet system.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SignetConstants {
@@ -260,5 +275,19 @@ impl SignetConstants {
     /// Get the environment constants.
     pub const fn environment(&self) -> &SignetEnvironmentConstants {
         &self.environment
+    }
+}
+
+impl FromStr for SignetConstants {
+    type Err = ParseChainError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let s = s.trim().to_lowercase();
+        match s.as_str() {
+            "pecorino" => Ok(Self::pecorino()),
+            #[cfg(any(test, feature = "test-utils"))]
+            "test" => Ok(Self::test()),
+            _ => Err(ParseChainError::ChainNotSupported(s, "pecorino, test".to_string())),
+        }
     }
 }

--- a/crates/constants/src/types/rollup.rs
+++ b/crates/constants/src/types/rollup.rs
@@ -1,4 +1,4 @@
-use crate::types::{ConfigError, ParseChainError, PredeployTokens};
+use crate::types::{ConfigError, KnownChains, ParseChainError, PredeployTokens};
 use alloy::{
     genesis::Genesis,
     primitives::{address, Address},
@@ -111,12 +111,11 @@ impl FromStr for RollupConstants {
     type Err = ParseChainError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let s = s.trim().to_lowercase();
-        match s.as_str() {
-            "pecorino" => Ok(Self::pecorino()),
+        let chain: KnownChains = s.parse()?;
+        match chain {
+            KnownChains::Pecorino => Ok(Self::pecorino()),
             #[cfg(any(test, feature = "test-utils"))]
-            "test" => Ok(Self::test()),
-            _ => Err(ParseChainError::ChainNotSupported(s, "pecorino, test".to_string())),
+            KnownChains::Test => Ok(Self::test()),
         }
     }
 }

--- a/crates/constants/src/types/rollup.rs
+++ b/crates/constants/src/types/rollup.rs
@@ -1,9 +1,10 @@
-use crate::types::{ConfigError, PredeployTokens};
+use crate::types::{ConfigError, ParseChainError, PredeployTokens};
 use alloy::{
     genesis::Genesis,
     primitives::{address, Address},
 };
 use serde_json::Value;
+use std::str::FromStr;
 
 /// System address with permission to mint tokens. This is the address from
 /// which the node will issue transactions to mint ETH or ERC20 tokens.
@@ -103,5 +104,19 @@ impl RollupConstants {
     /// Get the address of the minter.
     pub const fn minter(&self) -> Address {
         MINTER_ADDRESS
+    }
+}
+
+impl FromStr for RollupConstants {
+    type Err = ParseChainError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let s = s.trim().to_lowercase();
+        match s.as_str() {
+            "pecorino" => Ok(Self::pecorino()),
+            #[cfg(any(test, feature = "test-utils"))]
+            "test" => Ok(Self::test()),
+            _ => Err(ParseChainError::ChainNotSupported(s, "pecorino, test".to_string())),
+        }
     }
 }

--- a/crates/extract/src/test_utils/host_spec.rs
+++ b/crates/extract/src/test_utils/host_spec.rs
@@ -15,7 +15,7 @@ use reth::{
     providers::{Chain, ExecutionOutcome},
 };
 use signet_types::{
-    constants::{ParseChainError, SignetSystemConstants},
+    constants::{KnownChains, ParseChainError, SignetSystemConstants},
     AggregateFills,
 };
 use signet_zenith::{Passage, RollupOrders, Transactor};
@@ -414,12 +414,11 @@ impl FromStr for HostBlockSpec {
     type Err = ParseChainError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let s = s.trim().to_lowercase();
-        match s.as_str() {
-            "pecorino" => Ok(Self::pecorino()),
+        let chain: KnownChains = s.parse()?;
+        match chain {
+            KnownChains::Pecorino => Ok(Self::pecorino()),
             #[cfg(any(test, feature = "test-utils"))]
-            "test" => Ok(Self::test()),
-            _ => Err(ParseChainError::ChainNotSupported(s, "pecorino, test".to_string())),
+            KnownChains::Test => Ok(Self::test()),
         }
     }
 }

--- a/crates/extract/src/test_utils/host_spec.rs
+++ b/crates/extract/src/test_utils/host_spec.rs
@@ -14,10 +14,14 @@ use reth::{
     },
     providers::{Chain, ExecutionOutcome},
 };
-use signet_types::{constants::SignetSystemConstants, AggregateFills};
+use signet_types::{
+    constants::{ParseChainError, SignetSystemConstants},
+    AggregateFills,
+};
 use signet_zenith::{Passage, RollupOrders, Transactor};
 use std::{
     borrow::Borrow,
+    str::FromStr,
     sync::atomic::{AtomicU64, Ordering},
 };
 
@@ -403,6 +407,20 @@ impl HostBlockSpec {
         assert!(enter_tokens.next().is_none());
         assert!(transacts.next().is_none());
         assert_eq!(extracts.aggregate_fills(), context);
+    }
+}
+
+impl FromStr for HostBlockSpec {
+    type Err = ParseChainError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let s = s.trim().to_lowercase();
+        match s.as_str() {
+            "pecorino" => Ok(Self::pecorino()),
+            #[cfg(any(test, feature = "test-utils"))]
+            "test" => Ok(Self::test()),
+            _ => Err(ParseChainError::ChainNotSupported(s, "pecorino, test".to_string())),
+        }
     }
 }
 

--- a/crates/extract/src/test_utils/ru_spec.rs
+++ b/crates/extract/src/test_utils/ru_spec.rs
@@ -9,8 +9,9 @@ use alloy::{
     signers::local::PrivateKeySigner,
 };
 use reth::primitives::TransactionSigned;
-use signet_types::constants::SignetSystemConstants;
+use signet_types::constants::{ParseChainError, SignetSystemConstants};
 use signet_zenith::Zenith::{self};
+use std::str::FromStr;
 
 /// A block spec for the Ru chain.
 ///
@@ -141,6 +142,20 @@ impl RuBlockSpec {
 
         if let Some(reward_address) = self.reward_address {
             assert_eq!(submitted.reward_address(), reward_address)
+        }
+    }
+}
+
+impl FromStr for RuBlockSpec {
+    type Err = ParseChainError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let s = s.trim().to_lowercase();
+        match s.as_str() {
+            "pecorino" => Ok(Self::pecorino()),
+            #[cfg(any(test, feature = "test-utils"))]
+            "test" => Ok(Self::test()),
+            _ => Err(ParseChainError::ChainNotSupported(s, "pecorino, test".to_string())),
         }
     }
 }

--- a/crates/extract/src/test_utils/ru_spec.rs
+++ b/crates/extract/src/test_utils/ru_spec.rs
@@ -9,7 +9,7 @@ use alloy::{
     signers::local::PrivateKeySigner,
 };
 use reth::primitives::TransactionSigned;
-use signet_types::constants::{ParseChainError, SignetSystemConstants};
+use signet_types::constants::{KnownChains, ParseChainError, SignetSystemConstants};
 use signet_zenith::Zenith::{self};
 use std::str::FromStr;
 
@@ -150,12 +150,11 @@ impl FromStr for RuBlockSpec {
     type Err = ParseChainError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let s = s.trim().to_lowercase();
-        match s.as_str() {
-            "pecorino" => Ok(Self::pecorino()),
+        let chain: KnownChains = s.parse()?;
+        match chain {
+            KnownChains::Pecorino => Ok(Self::pecorino()),
             #[cfg(any(test, feature = "test-utils"))]
-            "test" => Ok(Self::test()),
-            _ => Err(ParseChainError::ChainNotSupported(s, "pecorino, test".to_string())),
+            KnownChains::Test => Ok(Self::test()),
         }
     }
 }


### PR DESCRIPTION
in service of implementing `FromEnvVar` in [bin-base](https://github.com/init4tech/bin-base/) using `impl_for_parseable!` [macro](https://github.com/init4tech/bin-base/blob/7a693c002273142da3fa1727222d19ffb55258f7/src/utils/from_env.rs#L584C14-L584C32)

Implemented for all types with `pecorino()`/`test()` instantiations, _except_ purposefully did not implement for `TxCache` because I thought we may want the behavior for that to be different - e.g. treat the env var as the tx cache endpoint.