### PR TITLE
chore: trim some reth imports

### DIFF
--- a/crates/evm/src/driver.rs
+++ b/crates/evm/src/driver.rs
@@ -4,22 +4,16 @@ use crate::{
     BlockResult, EvmNeedsTx, EvmTransacted, RunTxResult, SignetLayered, ToRethPrimitive, BASE_GAS,
 };
 use alloy::{
-    consensus::{ReceiptEnvelope, Transaction as _},
+    consensus::{Header, ReceiptEnvelope, Transaction as _, TxType},
     eips::eip1559::{BaseFeeParams, INITIAL_BASE_FEE as EIP1559_INITIAL_BASE_FEE},
     primitives::{Address, Bloom, U256},
 };
 use reth::{
     core::primitives::SignedTransaction,
     primitives::{
-        Block, BlockBody, Header, Receipt, RecoveredBlock, SealedHeader, Transaction,
-        TransactionSigned, TxType,
+        Block, BlockBody, Receipt, RecoveredBlock, SealedHeader, Transaction, TransactionSigned,
     },
     providers::ExecutionOutcome,
-    revm::{
-        context::{ContextTr, TransactTo},
-        context_interface::block::BlobExcessGasAndPrice,
-        Inspector,
-    },
 };
 use signet_extract::{ExtractedEvent, Extracts};
 use signet_types::{constants::SignetSystemConstants, AggregateFills, MarketError};
@@ -32,10 +26,11 @@ use trevm::{
     revm::{
         context::{
             result::{EVMError, ExecutionResult},
-            BlockEnv, CfgEnv, TxEnv,
+            BlockEnv, CfgEnv, ContextTr, TransactTo, TxEnv,
         },
+        context_interface::block::BlobExcessGasAndPrice,
         database::State,
-        Database, DatabaseCommit,
+        Database, DatabaseCommit, Inspector,
     },
     trevm_try, BlockDriver, BlockOutput, Tx,
 };

--- a/crates/evm/src/journal/coder.rs
+++ b/crates/evm/src/journal/coder.rs
@@ -2,12 +2,12 @@ use crate::{AcctDiff, BundleStateIndex, HostJournal, InfoOutcome};
 use alloy::primitives::{Address, Bytes, B256, U256};
 use alloy::rlp::{Buf, BufMut};
 use eyre::Result;
-use reth::revm::{
+use signet_zenith::Zenith;
+use std::{borrow::Cow, collections::BTreeMap, fmt::Debug, sync::Arc};
+use trevm::revm::{
     db::{states::StorageSlot, BundleState},
     primitives::{AccountInfo, Bytecode, Eof},
 };
-use std::{borrow::Cow, collections::BTreeMap, fmt::Debug, sync::Arc};
-use signet_zenith::Zenith;
 
 const TAG_ACCT_CREATED: u8 = 0;
 const TAG_ACCT_DIFF: u8 = 1;

--- a/crates/evm/src/lib.rs
+++ b/crates/evm/src/lib.rs
@@ -43,14 +43,6 @@ mod sys_log;
 
 pub(crate) const BASE_GAS: usize = 21_000;
 
-/// Type alias for EVMs using a [`StateProviderBox`] as the `DB` type for
-/// trevm.
-///
-/// [`StateProviderBox`]: reth::providers::StateProviderBox
-pub type RuRevmState = reth::revm::db::State<
-    reth::revm::database::StateProviderDatabase<reth::providers::StateProviderBox>,
->;
-
 /// Create a new EVM with the given database.
 pub fn signet_evm<Db: Database + DatabaseCommit>(
     db: Db,

--- a/crates/evm/src/orders/inspector.rs
+++ b/crates/evm/src/orders/inspector.rs
@@ -3,7 +3,6 @@ use alloy::{
     primitives::{Address, Log, U256},
     sol_types::SolEvent,
 };
-use reth::revm::interpreter::InterpreterTypes;
 use signet_types::{constants::SignetSystemConstants, AggregateFills, AggregateOrders};
 use signet_zenith::RollupOrders;
 use trevm::{
@@ -11,6 +10,7 @@ use trevm::{
     revm::{
         interpreter::{
             CallInputs, CallOutcome, CreateInputs, CreateOutcome, EOFCreateInputs, Interpreter,
+            InterpreterTypes,
         },
         Database, Inspector,
     },

--- a/crates/evm/src/orders/mod.rs
+++ b/crates/evm/src/orders/mod.rs
@@ -4,11 +4,13 @@ pub use framed::{Framed, FramedFilleds, FramedOrders};
 mod inspector;
 pub use inspector::OrderDetector;
 
-use reth::revm::interpreter::{interpreter::EthInterpreter, InterpreterTypes};
 use trevm::{
     helpers::Ctx,
     inspectors::Layered,
-    revm::{Database, Inspector},
+    revm::{
+        interpreter::{interpreter::EthInterpreter, InterpreterTypes},
+        Database, Inspector,
+    },
 };
 
 /// Inspector containing an accessible [`OrderDetector`].

--- a/crates/rpc/src/ctx.rs
+++ b/crates/rpc/src/ctx.rs
@@ -40,7 +40,7 @@ use reth::{
 use reth_chainspec::{BaseFeeParams, ChainSpec, ChainSpecProvider};
 use reth_node_api::{BlockBody, FullNodeComponents};
 use reth_rpc_eth_api::{RpcBlock, RpcReceipt, RpcTransaction};
-use signet_evm::{EvmNeedsTx, RuRevmState};
+use signet_evm::EvmNeedsTx;
 use signet_tx_cache::client::TxCache;
 use signet_types::{constants::SignetSystemConstants, MagicSig};
 use std::{marker::PhantomData, sync::Arc};
@@ -49,6 +49,14 @@ use trevm::{
     revm::{context::CfgEnv, database::StateBuilder},
     Cfg,
 };
+
+/// Type alias for EVMs using a [`StateProviderBox`] as the `DB` type for
+/// trevm.
+///
+/// [`StateProviderBox`]: reth::providers::StateProviderBox
+pub type RuRevmState = trevm::revm::database::State<
+    reth::revm::database::StateProviderDatabase<reth::providers::StateProviderBox>,
+>;
 
 /// The maximum number of headers we read at once when handling a range filter.
 const MAX_HEADERS_RANGE: u64 = 1_000; // with ~530bytes per header this is ~500kb

--- a/crates/rpc/src/lib.rs
+++ b/crates/rpc/src/lib.rs
@@ -52,7 +52,7 @@ mod config;
 pub use config::{RpcServerGuard, ServeConfig};
 
 mod ctx;
-pub use ctx::RpcCtx;
+pub use ctx::{RpcCtx, RuRevmState};
 
 mod eth;
 pub use eth::{eth, CallErrorData, EthError};


### PR DESCRIPTION
Cleans up some imports by moving them out of reth. Thinking long-term we'd like to remove reth as a dep here