### PR TITLE
chore(tx-cache): add method to forward without decoding response bodies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 rust-version = "1.81"
 authors = ["init4"]

--- a/crates/tx-cache/src/client.rs
+++ b/crates/tx-cache/src/client.rs
@@ -78,7 +78,7 @@ impl TxCache {
             .inspect_err(|e| warn!(%e, "Failed to parse response from transaction cache"))
     }
 
-    async fn forward_inner_silent<T: Serialize + Send>(
+    async fn forward_inner_no_response<T: Serialize + Send>(
         &self,
         join: &'static str,
         obj: T,
@@ -147,7 +147,7 @@ impl TxCache {
     /// Forward an order to the URL.
     #[instrument(skip_all)]
     pub async fn forward_order(&self, order: SignedOrder) -> Result<(), Error> {
-        self.forward_inner_silent(ORDERS, order).await
+        self.forward_inner_no_response(ORDERS, order).await
     }
 
     /// Get transactions from the URL.


### PR DESCRIPTION
Only checks for success. Useful for any API handlers that do not return any data, like the Orders PUT handler