### PR TITLE
chore(tx-cache): remove permissioned endpoints

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.2.4"
+version = "0.3.0"
 edition = "2021"
 rust-version = "1.81"
 authors = ["init4"]
@@ -34,16 +34,16 @@ debug = false
 incremental = false
 
 [workspace.dependencies]
-signet-bundle = { version = "0.2.0", path = "crates/bundle" }
-signet-constants = { version = "0.2.0", path = "crates/constants" }
-signet-evm = { version = "0.2.0", path = "crates/evm" }
-signet-extract = { version = "0.2.0", path = "crates/extract" }
-signet-node = { version = "0.2.0", path = "crates/node" }
-signet-rpc = { version = "0.2.0", path = "crates/rpc" }
-signet-sim = { version = "0.2.0", path = "crates/sim" }
-signet-types = { version = "0.2.0", path = "crates/types" }
-signet-tx-cache = { version = "0.2.0", path = "crates/tx-cache" }
-signet-zenith = { version = "0.2.0", path = "crates/zenith" }
+signet-bundle = { version = "0.3.0", path = "crates/bundle" }
+signet-constants = { version = "0.3.0", path = "crates/constants" }
+signet-evm = { version = "0.3.0", path = "crates/evm" }
+signet-extract = { version = "0.3.0", path = "crates/extract" }
+signet-node = { version = "0.3.0", path = "crates/node" }
+signet-rpc = { version = "0.3.0", path = "crates/rpc" }
+signet-sim = { version = "0.3.0", path = "crates/sim" }
+signet-types = { version = "0.3.0", path = "crates/types" }
+signet-tx-cache = { version = "0.3.0", path = "crates/tx-cache" }
+signet-zenith = { version = "0.3.0", path = "crates/zenith" }
 
 # ajj
 ajj = { version = "0.3.4" }

--- a/crates/tx-cache/src/client.rs
+++ b/crates/tx-cache/src/client.rs
@@ -1,6 +1,6 @@
 use crate::types::{
-    TxCacheBundle, TxCacheBundleResponse, TxCacheBundlesResponse, TxCacheOrdersResponse,
-    TxCacheSendBundleResponse, TxCacheSendTransactionResponse, TxCacheTransactionsResponse,
+    TxCacheOrdersResponse, TxCacheSendBundleResponse, TxCacheSendTransactionResponse,
+    TxCacheTransactionsResponse,
 };
 use alloy::consensus::TxEnvelope;
 use eyre::Error;
@@ -133,22 +133,6 @@ impl TxCache {
         let response: TxCacheTransactionsResponse =
             self.get_inner::<TxCacheTransactionsResponse>(TRANSACTIONS).await?;
         Ok(response.transactions)
-    }
-
-    /// Get bundles from the URL.
-    #[instrument(skip_all)]
-    pub async fn get_bundles(&self) -> Result<Vec<TxCacheBundle>, Error> {
-        let response: TxCacheBundlesResponse =
-            self.get_inner::<TxCacheBundlesResponse>(BUNDLES).await?;
-        Ok(response.bundles)
-    }
-
-    /// Get a bundle from the URL.
-    #[instrument(skip_all)]
-    pub async fn get_bundle(&self) -> Result<TxCacheBundle, Error> {
-        let response: TxCacheBundleResponse =
-            self.get_inner::<TxCacheBundleResponse>(BUNDLES).await?;
-        Ok(response.bundle)
     }
 
     /// Get signed orders from the URL.


### PR DESCRIPTION
These endpoints are never really used by normal SDK consumers. We should remove them.