### PR TITLE
clarify between `cache_rank` and `identifier`

### DIFF
--- a/crates/sim/src/cache.rs
+++ b/crates/sim/src/cache.rs
@@ -48,7 +48,7 @@ impl SimCache {
             .iter()
             .rev()
             .take(n)
-            .map(|(fee_score, item)| (*fee_score, item.clone()))
+            .map(|(cache_rank, item)| (*cache_rank, item.clone()))
             .collect()
     }
 
@@ -63,14 +63,14 @@ impl SimCache {
     }
 
     /// Get an item by key.
-    pub fn get(&self, fee_score: u128) -> Option<SimItem> {
-        self.inner.read().items.get(&fee_score).cloned()
+    pub fn get(&self, cache_rank: u128) -> Option<SimItem> {
+        self.inner.read().items.get(&cache_rank).cloned()
     }
 
     /// Remove an item by key.
-    pub fn remove(&self, fee_score: u128) -> Option<SimItem> {
+    pub fn remove(&self, cache_rank: u128) -> Option<SimItem> {
         let mut inner = self.inner.write();
-        if let Some(item) = inner.items.remove(&fee_score) {
+        if let Some(item) = inner.items.remove(&cache_rank) {
             inner.seen.remove(item.identifier().as_bytes());
             Some(item)
         } else {
@@ -78,15 +78,15 @@ impl SimCache {
         }
     }
 
-    fn add_inner(inner: &mut CacheInner, mut fee_score: u128, item: SimItem, capacity: usize) {
+    fn add_inner(inner: &mut CacheInner, mut cache_rank: u128, item: SimItem, capacity: usize) {
         // Check if we've already seen this item - if so, don't add it
         if !inner.seen.insert(item.identifier_owned()) {
             return;
         }
 
-        // If it has the same fee_score, we decrement (prioritizing earlier items)
-        while inner.items.contains_key(&fee_score) && fee_score != 0 {
-            fee_score = fee_score.saturating_sub(1);
+        // If it has the same cache_rank, we decrement (prioritizing earlier items)
+        while inner.items.contains_key(&cache_rank) && cache_rank != 0 {
+            cache_rank = cache_rank.saturating_sub(1);
         }
 
         if inner.items.len() >= capacity {
@@ -96,7 +96,7 @@ impl SimCache {
             }
         }
 
-        inner.items.insert(fee_score, item.clone());
+        inner.items.insert(cache_rank, item.clone());
     }
 
     /// Add a bundle to the cache.
@@ -107,10 +107,10 @@ impl SimCache {
         }
 
         let item = SimItem::try_from(bundle)?;
-        let fee_score = item.calculate_total_fee(basefee);
+        let cache_rank = item.calculate_total_fee(basefee);
 
         let mut inner = self.inner.write();
-        Self::add_inner(&mut inner, fee_score, item, self.capacity);
+        Self::add_inner(&mut inner, cache_rank, item, self.capacity);
 
         Ok(())
     }
@@ -131,8 +131,8 @@ impl SimCache {
                 // Skip invalid bundles
                 continue;
             };
-            let fee_score = item.calculate_total_fee(basefee);
-            Self::add_inner(&mut inner, fee_score, item, self.capacity);
+            let cache_rank = item.calculate_total_fee(basefee);
+            Self::add_inner(&mut inner, cache_rank, item, self.capacity);
         }
 
         Ok(())
@@ -141,10 +141,10 @@ impl SimCache {
     /// Add a transaction to the cache.
     pub fn add_tx(&self, tx: TxEnvelope, basefee: u64) {
         let item = SimItem::from(tx);
-        let fee_score = item.calculate_total_fee(basefee);
+        let cache_rank = item.calculate_total_fee(basefee);
 
         let mut inner = self.inner.write();
-        Self::add_inner(&mut inner, fee_score, item, self.capacity);
+        Self::add_inner(&mut inner, cache_rank, item, self.capacity);
     }
 
     /// Add an iterator of transactions to the cache. This locks the cache only once
@@ -156,8 +156,8 @@ impl SimCache {
 
         for item in item.into_iter() {
             let item = SimItem::from(item);
-            let fee_score = item.calculate_total_fee(basefee);
-            Self::add_inner(&mut inner, fee_score, item, self.capacity);
+            let cache_rank = item.calculate_total_fee(basefee);
+            Self::add_inner(&mut inner, cache_rank, item, self.capacity);
         }
     }
 
@@ -203,7 +203,7 @@ impl SimCache {
 
 /// Internal cache data, meant to be protected by a lock.
 struct CacheInner {
-    /// Key is the fee_score, the calculated gas fees from the transaction. Value is SimItem itself.
+    /// Key is the cache_rank, unique ID within the cache && the item's order in the cache. Value is SimItem itself.
     items: BTreeMap<u128, SimItem>,
     /// Key is the unique identifier for the SimItem. UUID for bundles, tx hash for transactions.
     seen: HashSet<SimIdentifier<'static>>,

--- a/crates/sim/src/cache.rs
+++ b/crates/sim/src/cache.rs
@@ -203,9 +203,9 @@ impl SimCache {
 
 /// Internal cache data, meant to be protected by a lock.
 struct CacheInner {
-    /// Key is the cache_rank, unique ID within the cache && the item's order in the cache. Value is SimItem itself.
+    /// Key is the cache_rank, unique ID within the cache && the item's order in the cache. Value is [`SimItem`] itself.
     items: BTreeMap<u128, SimItem>,
-    /// Key is the unique identifier for the SimItem - the UUID for bundles, tx hash for transactions.
+    /// Key is the unique identifier for the [`SimItem`] - the UUID for bundles, tx hash for transactions.
     seen: HashSet<SimIdentifier<'static>>,
 }
 

--- a/crates/sim/src/cache.rs
+++ b/crates/sim/src/cache.rs
@@ -205,7 +205,7 @@ impl SimCache {
 struct CacheInner {
     /// Key is the cache_rank, unique ID within the cache && the item's order in the cache. Value is SimItem itself.
     items: BTreeMap<u128, SimItem>,
-    /// Key is the unique identifier for the SimItem. UUID for bundles, tx hash for transactions.
+    /// Key is the unique identifier for the SimItem - the UUID for bundles, tx hash for transactions.
     seen: HashSet<SimIdentifier<'static>>,
 }
 

--- a/crates/sim/src/env.rs
+++ b/crates/sim/src/env.rs
@@ -85,12 +85,12 @@ where
     /// Run a simulation round, returning the best item.
     #[instrument(skip(self))]
     pub async fn sim_round(&mut self, max_gas: u64) -> Option<SimulatedItem> {
-        let (best_tx_sender, mut best_tx_receiver) = watch::channel(None);
+        let (best_tx, mut best_watcher) = watch::channel(None);
 
         let this = self.inner.clone();
 
         // Spawn a blocking task to run the simulations.
-        let sim_task = tokio::task::spawn_blocking(move || this.sim_round(max_gas, best_tx_sender));
+        let sim_task = tokio::task::spawn_blocking(move || this.sim_round(max_gas, best_tx));
 
         // Either simulation is done, or we time out
         select! {
@@ -103,7 +103,7 @@ where
         }
 
         // Check what the current best outcome is.
-        let best = best_tx_receiver.borrow_and_update();
+        let best = best_watcher.borrow_and_update();
         trace!(score = %best.as_ref().map(|candidate| candidate.score).unwrap_or_default(), "Read outcome from channel");
         let outcome = best.as_ref()?;
 
@@ -310,7 +310,7 @@ where
                     halted,
                     halt_reason = ?if halted { halt_reason } else { None },
                     revert_reason = if !success { reason } else { None },
-                    "Transaction simulation successful"
+                    "Transaction simulation complete"
                 );
 
                 // Create the outcome
@@ -371,7 +371,7 @@ where
     fn sim_round(
         self: Arc<Self>,
         max_gas: u64,
-        best_tx_sender: watch::Sender<Option<SimOutcomeWithCache>>,
+        best_tx: watch::Sender<Option<SimOutcomeWithCache>>,
     ) {
         // Pull the `n` best items from the cache.
         let active_sim = self.sim_items.read_best(self.concurrency_limit);
@@ -422,14 +422,14 @@ where
             // Wait for each thread to finish. Find the best outcome.
             while let Some(candidate) = candidates_rx.blocking_recv() {
                 // Update the best score and send it to the channel.
-                let _ = best_tx_sender.send_if_modified(|current| {
-                    let current_best_score = current.as_ref().map(|c| c.score).unwrap_or_default();
+                let _ = best_tx.send_if_modified(|current| {
+                    let best_score = current.as_ref().map(|c| c.score).unwrap_or_default();
                     let current_cache_rank = current.as_ref().map(|c| c.cache_rank);
 
-                    let changed = candidate.score > current_best_score;
+                    let changed = candidate.score > best_score;
                     if changed {
                         trace!(
-                            old_best = ?current_best_score,
+                            old_best = ?best_score,
                             old_cache_rank = current_cache_rank,
                             new_best = %candidate.score,
                             new_cache_rank = candidate.cache_rank,

--- a/crates/sim/src/env.rs
+++ b/crates/sim/src/env.rs
@@ -310,7 +310,7 @@ where
                     halted,
                     halt_reason = ?if halted { halt_reason } else { None },
                     revert_reason = if !success { reason } else { None },
-                    "Simulation complete"
+                    "Transaction simulation successful"
                 );
 
                 // Create the outcome
@@ -346,7 +346,7 @@ where
 
         trace!(
             ?cache_rank,
-            uuid = %bundle.replacement_uuid().unwrap_or_default(),
+            uuid = %bundle.replacement_uuid().expect("Bundle must have a replacement UUID"),
             gas_used = gas_used,
             score = %score,
             "Bundle simulation successful"
@@ -404,7 +404,7 @@ where
                                 let _ = c.blocking_send(candidate);
                                 return;
                             }
-                            trace!(gas_used = candidate.gas_used, max_gas, "Gas limit exceeded");
+                            trace!(gas_used = candidate.gas_used, max_gas, %identifier, "Gas limit exceeded");
                         }
                         Err(e) => {
                             trace!(?identifier, %e, "Simulation failed");

--- a/crates/sim/src/env.rs
+++ b/crates/sim/src/env.rs
@@ -346,6 +346,7 @@ where
 
         trace!(
             ?cache_rank,
+            uuid = %bundle.replacement_uuid().unwrap_or_default(),
             gas_used = gas_used,
             score = %score,
             "Bundle simulation successful"

--- a/crates/sim/src/outcome.rs
+++ b/crates/sim/src/outcome.rs
@@ -7,7 +7,7 @@ use crate::SimItem;
 /// state changes.
 #[derive(Debug, Clone)]
 pub struct SimOutcomeWithCache {
-    /// The transaction or bundle that was simulated, as in the cache.
+    /// The fee score calculated for the transaction or bundle that was simulated; also its key in the cache.
     pub identifier: u128,
 
     /// The score of the simulation, a [`U256`] value that represents the

--- a/crates/sim/src/outcome.rs
+++ b/crates/sim/src/outcome.rs
@@ -7,7 +7,7 @@ use crate::SimItem;
 /// state changes.
 #[derive(Debug, Clone)]
 pub struct SimOutcomeWithCache {
-    /// The key for the item in the SimCache.
+    /// The key for the item in the [`SimCache`].
     pub cache_rank: u128,
 
     /// The score of the simulation, a [`U256`] value that represents the

--- a/crates/sim/src/outcome.rs
+++ b/crates/sim/src/outcome.rs
@@ -7,8 +7,8 @@ use crate::SimItem;
 /// state changes.
 #[derive(Debug, Clone)]
 pub struct SimOutcomeWithCache {
-    /// The fee score calculated for the transaction or bundle that was simulated; also its key in the cache.
-    pub identifier: u128,
+    /// The key for the item in the SimCache.
+    pub cache_rank: u128,
 
     /// The score of the simulation, a [`U256`] value that represents the
     /// increase in the beneficiary's balance.


### PR DESCRIPTION
The SimItems cache key was variably names as `score`, `identifier`, and `key`. However, `score` and `identifier` are both also used elsewhere in this code to refer to different values. I found this to make the code less readable.

This PR
- Differentiates between `cache_rank` (the item's ordering within the cache) and `score` (final, actual simulation score based on beneficiary balance change) 
- Differentiates between `cache_rank` and `identifier` (tx hash for txns, UUID for bundles)

Also updates logging to use SimItem `identifier` (rather than `cache_rank`) to make the logs more readable & searchable.