### PR TITLE
fix(sim): Make simulation process actually continuous

### DIFF
--- a/crates/sim/src/task.rs
+++ b/crates/sim/src/task.rs
@@ -102,6 +102,7 @@ where
             let fut = self.round().instrument(span);
 
             select! {
+                biased;
                 _ = tokio::time::sleep_until(finish_by) => {
                     debug!("Deadline reached, stopping sim loop");
                     break;

--- a/crates/sim/src/task.rs
+++ b/crates/sim/src/task.rs
@@ -1,6 +1,6 @@
-use std::time::Duration;
 use crate::{env::SimEnv, BuiltBlock, SharedSimEnv, SimCache, SimDb};
 use signet_types::constants::SignetSystemConstants;
+use std::time::Duration;
 use tokio::{select, time::Instant};
 use tracing::{debug, info_span, trace, Instrument};
 use trevm::{
@@ -81,21 +81,21 @@ where
             let span = info_span!("build", round = i);
             let finish_by = self.finish_by.into();
 
+            let next_round_time = Instant::now() + Duration::from_millis(SIM_SLEEP_MS);
+
+            // If the next round time is past the deadline, we stop the simulation loop.
+            // This will stop the simulation even if there are items, but that is an acceptable tradeoff
+            // as we must ensure there's enough time to submit the blob to the host chain.
+            if next_round_time >= finish_by {
+                debug!("Next round time is past the deadline, stopping sim loop");
+                break;
+            }
+
             // Only simulate if there are items to simulate.
             // If there are not items, we sleep for the minimum of 50ms or until the deadline is reached,
             // and restart the loop.
             if self.env.sim_items().is_empty() {
-                debug!("No items to simulate. Skipping simulation round");
-                let sleep_until =
-                    (Instant::now() + Duration::from_millis(SIM_SLEEP_MS)).min(finish_by);
-                tokio::time::sleep_until(sleep_until).instrument(span).await;
-
-                // If we sleep until the deadline, we just break the loop.
-                if sleep_until == finish_by {
-                    debug!("Deadline reached, stopping sim loop");
-                    break;
-                }
-
+                tokio::time::sleep_until(next_round_time).await;
                 continue;
             }
 

--- a/crates/sim/src/task.rs
+++ b/crates/sim/src/task.rs
@@ -1,5 +1,4 @@
 use std::time::Duration;
-
 use crate::{env::SimEnv, BuiltBlock, SharedSimEnv, SimCache, SimDb};
 use signet_types::constants::SignetSystemConstants;
 use tokio::{select, time::Instant};

--- a/crates/sim/src/task.rs
+++ b/crates/sim/src/task.rs
@@ -86,6 +86,13 @@ where
                 debug!("No items to simulate. Skipping simulation round");
                 let sleep_until = (Instant::now() + Duration::from_millis(50)).min(finish_by);
                 tokio::time::sleep_until(sleep_until).instrument(span).await;
+
+                // If we sleep until the deadline, we just break the loop.
+                if sleep_until == finish_by {
+                    debug!("Deadline reached, stopping sim loop");
+                    break;
+                }
+
                 continue;
             }
 

--- a/crates/sim/src/task.rs
+++ b/crates/sim/src/task.rs
@@ -10,6 +10,9 @@ use trevm::{
     Block, Cfg,
 };
 
+/// The amount of time to sleep between simulation rounds when there are no items to simulate.
+pub(crate) const SIM_SLEEP_MS: u64 = 50;
+
 /// Builds a single block by repeatedly invoking [`SimEnv`].
 #[derive(Debug)]
 pub struct BlockBuild<Db, Insp = NoOpInspector> {
@@ -84,7 +87,8 @@ where
             // and restart the loop.
             if self.env.sim_items().is_empty() && Instant::now() >= finish_by {
                 debug!("No items to simulate. Skipping simulation round");
-                let sleep_until = (Instant::now() + Duration::from_millis(50)).min(finish_by);
+                let sleep_until =
+                    (Instant::now() + Duration::from_millis(SIM_SLEEP_MS)).min(finish_by);
                 tokio::time::sleep_until(sleep_until).instrument(span).await;
 
                 // If we sleep until the deadline, we just break the loop.

--- a/crates/sim/src/task.rs
+++ b/crates/sim/src/task.rs
@@ -92,8 +92,7 @@ where
             }
 
             // Only simulate if there are items to simulate.
-            // If there are not items, we sleep for the minimum of 50ms or until the deadline is reached,
-            // and restart the loop.
+            // If there are not items, we sleep for [`SIM_SLEEP_MS`] and restart the loop.
             if self.env.sim_items().is_empty() {
                 tokio::time::sleep_until(next_round_time).await;
                 continue;

--- a/crates/sim/src/task.rs
+++ b/crates/sim/src/task.rs
@@ -85,7 +85,7 @@ where
             // Only simulate if there are items to simulate.
             // If there are not items, we sleep for the minimum of 50ms or until the deadline is reached,
             // and restart the loop.
-            if self.env.sim_items().is_empty() && Instant::now() >= finish_by {
+            if self.env.sim_items().is_empty() {
                 debug!("No items to simulate. Skipping simulation round");
                 let sleep_until =
                     (Instant::now() + Duration::from_millis(SIM_SLEEP_MS)).min(finish_by);


### PR DESCRIPTION
fix(sim): Make simulation process actually continuous

Right now, the simulator stops as soon as there are no more items to simulate. This actually is not correct behavior, as we could be early in the slot, with more items coming in later in the slot which could yield a higher total payout on the block.

What we actually want, is to simply skip doing the round at all if there are no items, sleep for a certain amount of time (bounded by the deadline), and either break (if we slept until the deadline) or continue if there's still time remaining.

The resulting behavior is that the simulator always runs until the deadline, ensuring that items that come later in the slot, up until the deadline, can be simulated and included in the block.

chore: properly break if we sleep until deadline