### PR TITLE
chore(tests): Make timestamp divisible by 12 to conform to slot invariant

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.6.0"
+version = "0.6.1"
 edition = "2021"
 rust-version = "1.81"
 authors = ["init4"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.6.1"
+version = "0.6.0"
 edition = "2021"
 rust-version = "1.81"
 authors = ["init4"]

--- a/crates/test-utils/src/chain.rs
+++ b/crates/test-utils/src/chain.rs
@@ -58,7 +58,7 @@ pub fn fake_block(number: u64) -> RecoveredBlock {
         number,
         mix_hash: B256::repeat_byte(0xed),
         nonce: B64::repeat_byte(0xbe),
-        timestamp: 1716555586, // the time when i wrote this function lol
+        timestamp: 1716555576, // no particular significance other than divisible by 12
         excess_blob_gas: Some(0),
         ..Default::default()
     };


### PR DESCRIPTION
Right now, this timestamp isn't divisible by 12. After fixing the bug we had on blob extraction on the node (https://github.com/init4tech/signet-node/pull/557/files#diff-c630b8329efc76498eaf78bdf3073dcdaefaacb9325e5731b7d1d8cae855d791R262), we now don't conform to an invariant that the calculator has when using `slot_ending_at`: The timestamp must be a slot boundary. We know if it's a slot boundary if it's divisible by 12 in the context of the start timestamp. For tests, this is 0, so any timestamp divisible by 12 will do.