### PR TITLE
chore(test-utils): also make sealed header timestamp divisible by 12

### DIFF
--- a/crates/test-utils/src/specs/host_spec.rs
+++ b/crates/test-utils/src/specs/host_spec.rs
@@ -314,7 +314,7 @@ impl HostBlockSpec {
             number: self.block_number(),
             mix_hash: B256::repeat_byte(0xed),
             nonce: FixedBytes::repeat_byte(0xbe),
-            timestamp: 1716555586, // the time when i wrote this function lol
+            timestamp: 1716555576,
             excess_blob_gas: Some(0),
             ..Default::default()
         };


### PR DESCRIPTION
didn't change this.