### PR TITLE
chore(deps): bump version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.6.0"
+version = "0.7.0"
 edition = "2021"
 rust-version = "1.81"
 authors = ["init4"]
@@ -34,16 +34,16 @@ debug = false
 incremental = false
 
 [workspace.dependencies]
-signet-bundle = { version = "0.6.0", path = "crates/bundle" }
-signet-constants = { version = "0.6.0", path = "crates/constants" }
-signet-evm = { version = "0.6.0", path = "crates/evm" }
-signet-extract = { version = "0.6.0", path = "crates/extract" }
-signet-node = { version = "0.6.0", path = "crates/node" }
-signet-rpc = { version = "0.6.0", path = "crates/rpc" }
-signet-sim = { version = "0.6.0", path = "crates/sim" }
-signet-types = { version = "0.6.0", path = "crates/types" }
-signet-tx-cache = { version = "0.6.0", path = "crates/tx-cache" }
-signet-zenith = { version = "0.6.0", path = "crates/zenith" }
+signet-bundle = { version = "0.7.0", path = "crates/bundle" }
+signet-constants = { version = "0.7.0", path = "crates/constants" }
+signet-evm = { version = "0.7.0", path = "crates/evm" }
+signet-extract = { version = "0.7.0", path = "crates/extract" }
+signet-node = { version = "0.7.0", path = "crates/node" }
+signet-rpc = { version = "0.7.0", path = "crates/rpc" }
+signet-sim = { version = "0.7.0", path = "crates/sim" }
+signet-types = { version = "0.7.0", path = "crates/types" }
+signet-tx-cache = { version = "0.7.0", path = "crates/tx-cache" }
+signet-zenith = { version = "0.7.0", path = "crates/zenith" }
 
 # ajj
 ajj = { version = "0.3.4" }


### PR DESCRIPTION
### TL;DR

Bump version from 0.6.0 to 0.7.0 across all workspace packages.

### What changed?

- Updated the workspace package version from 0.6.0 to 0.7.0 in the root Cargo.toml
- Updated all internal dependency versions from 0.6.0 to 0.7.0 for all signet crates:
  - signet-bundle
  - signet-constants
  - signet-evm
  - signet-extract
  - signet-node
  - signet-rpc
  - signet-sim
  - signet-types
  - signet-tx-cache
  - signet-zenith

### How to test?

- Verify that the project builds successfully with `cargo build`
- Run tests to ensure all dependencies resolve correctly with `cargo test`
- Check that any downstream projects depending on these crates can update to the new version

### Why make this change?

This version bump prepares for a new release with significant changes that warrant a minor version increment according to semantic versioning principles.