### PR TITLE
fix: export exexnotification

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.9.0"
+version = "0.9.1"
 edition = "2021"
 rust-version = "1.81"
 authors = ["init4"]

--- a/crates/test-utils/src/specs/mod.rs
+++ b/crates/test-utils/src/specs/mod.rs
@@ -2,7 +2,7 @@ mod host_spec;
 pub use host_spec::HostBlockSpec;
 
 mod notif_spec;
-pub use notif_spec::{NotificationSpec, NotificationWithSidecars};
+pub use notif_spec::{ExExNotification, NotificationSpec, NotificationWithSidecars};
 
 mod ru_spec;
 pub use ru_spec::RuBlockSpec;

--- a/crates/test-utils/src/specs/notif_spec.rs
+++ b/crates/test-utils/src/specs/notif_spec.rs
@@ -25,6 +25,26 @@ pub enum ExExNotification {
     },
 }
 
+impl ExExNotification {
+    /// Returns the committed chain, if any.
+    pub fn committed_chain(&self) -> Option<&Arc<Chain>> {
+        match self {
+            ExExNotification::Committed { new } => Some(new),
+            ExExNotification::Reorged { new, .. } => Some(new),
+            ExExNotification::Reverted { .. } => None,
+        }
+    }
+
+    /// Returns the reverted chain, if any.
+    pub fn reverted_chain(&self) -> Option<&Arc<Chain>> {
+        match self {
+            ExExNotification::Reorged { old, .. } => Some(old),
+            ExExNotification::Reverted { old } => Some(old),
+            ExExNotification::Committed { .. } => None,
+        }
+    }
+}
+
 /// A notification spec.
 #[derive(Debug, Default)]
 pub struct NotificationSpec {


### PR DESCRIPTION
Fix: make the type usable and not unnameable