### PR TITLE
fix: SignetEthBundleDriver now enforces market rules internally

### DIFF
--- a/crates/bundle/src/send/driver.rs
+++ b/crates/bundle/src/send/driver.rs
@@ -119,7 +119,7 @@ impl<'a> SignetEthBundleDriver<'a> {
     ///
     /// This may be used to check that the bundle does not overfill, by
     /// inspecting the agg fills after execution.
-    pub fn agg_fills(&self) -> &AggregateFills {
+    pub const fn agg_fills(&self) -> &AggregateFills {
         &self.agg_fills
     }
 

--- a/crates/sim/src/env.rs
+++ b/crates/sim/src/env.rs
@@ -330,7 +330,8 @@ where
     where
         Insp: Inspector<Ctx<SimDb<Db>>> + Default + Sync,
     {
-        let mut driver = SignetEthBundleDriver::new(bundle, self.finish_by);
+        let mut driver =
+            SignetEthBundleDriver::new(bundle, self.constants.host_chain_id(), self.finish_by);
         let trevm = self.create_with_block(&self.cfg, &self.block).unwrap();
 
         // Run the bundle

--- a/crates/types/src/agg/fill.rs
+++ b/crates/types/src/agg/fill.rs
@@ -1,5 +1,6 @@
 use crate::AggregateOrders;
 use crate::MarketError;
+use crate::SignedFill;
 use alloy::primitives::{Address, U256};
 use serde::{Deserialize, Serialize};
 use signet_zenith::RollupOrders;
@@ -105,6 +106,17 @@ impl AggregateFills {
     /// This uses saturating arithmetic to avoid panics. If filling more than
     /// [`U256::MAX`], re-examine life choices and don't do that.
     pub fn add_fill(&mut self, chain_id: u64, fill: &RollupOrders::Filled) {
+        fill.outputs.iter().for_each(|o| self.add_fill_output(chain_id, o));
+    }
+
+    /// Ingest a [`SignedFill`] into the aggregate. The chain_id is the ID
+    /// of the chain which emitted the event.
+    ///
+    /// # Note:
+    ///
+    /// This uses saturating arithmetic to avoid panics. If filling more than
+    /// [`U256::MAX`], re-examine life choices and don't do that.
+    pub fn add_signed_fill(&mut self, chain_id: u64, fill: &SignedFill) {
         fill.outputs.iter().for_each(|o| self.add_fill_output(chain_id, o));
     }
 


### PR DESCRIPTION
Adds Order enforcement to the bundle execution driver :)

A limitation of this is that it doesn't allow bundles that internally underfill (i.e. implicit dependencies on prior overfills)