### PR TITLE
chore: bump to 0.10.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.10.1"
+version = "0.10.2"
 edition = "2021"
 rust-version = "1.85"
 authors = ["init4"]


### PR DESCRIPTION
chore: prep for 0.10.2 release