### PR TITLE
fix(docs): Remove `auto_doc_cfg` usage

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.11.1"
+version = "0.11.2"
 edition = "2021"
 rust-version = "1.85"
 authors = ["init4"]

--- a/crates/bundle/src/lib.rs
+++ b/crates/bundle/src/lib.rs
@@ -44,7 +44,7 @@
 )]
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 #![deny(unused_must_use, rust_2018_idioms)]
-#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 mod call;
 pub use call::{SignetBundleDriver, SignetCallBundle, SignetCallBundleResponse};

--- a/crates/constants/src/lib.rs
+++ b/crates/constants/src/lib.rs
@@ -14,7 +14,7 @@
 )]
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 #![deny(unused_must_use, rust_2018_idioms)]
-#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 mod chains;
 pub use chains::test_utils;

--- a/crates/evm/src/lib.rs
+++ b/crates/evm/src/lib.rs
@@ -8,7 +8,7 @@
 )]
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 #![deny(unused_must_use, rust_2018_idioms)]
-#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 //! Signet EVM
 

--- a/crates/extract/src/lib.rs
+++ b/crates/extract/src/lib.rs
@@ -23,7 +23,7 @@
 )]
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 #![deny(unused_must_use, rust_2018_idioms)]
-#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 mod block;
 pub use block::Extracts;

--- a/crates/journal/src/lib.rs
+++ b/crates/journal/src/lib.rs
@@ -13,7 +13,7 @@
 )]
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 #![deny(unused_must_use, rust_2018_idioms)]
-#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 mod host;
 pub use host::HostJournal;

--- a/crates/sim/src/lib.rs
+++ b/crates/sim/src/lib.rs
@@ -12,7 +12,7 @@
 )]
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 #![deny(unused_must_use, rust_2018_idioms)]
-#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 mod built;
 pub use built::BuiltBlock;

--- a/crates/tx-cache/src/lib.rs
+++ b/crates/tx-cache/src/lib.rs
@@ -10,7 +10,7 @@
 )]
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 #![deny(unused_must_use, rust_2018_idioms)]
-#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 /// The [`TxCache`] client.
 pub mod client;

--- a/crates/types/src/lib.rs
+++ b/crates/types/src/lib.rs
@@ -13,7 +13,7 @@
 )]
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 #![deny(unused_must_use, rust_2018_idioms)]
-#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 /// Structs that hold Signet system configuration.
 pub use signet_constants as constants;

--- a/crates/zenith/src/lib.rs
+++ b/crates/zenith/src/lib.rs
@@ -9,7 +9,7 @@
 )]
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 #![deny(unused_must_use, rust_2018_idioms)]
-#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 mod bindings;
 pub use bindings::{


### PR DESCRIPTION
As per recommendation, see https://users.rust-lang.org/t/fallout-from-removal-of-doc-auto-cfg/134435