### PR TITLE
Add Claude pre-push hooks for clippy and doc checks

### DIFF
--- a/.claude/hooks/pre-push.sh
+++ b/.claude/hooks/pre-push.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Consume stdin (hook protocol)
+cat > /dev/null
+
+cd "$(dirname "$0")/../.."
+
+echo "Running pre-push checks..." >&2
+
+if ! cargo +nightly fmt -- --check 2>&1; then
+    echo "Format check failed. Run 'cargo +nightly fmt' to fix." >&2
+    exit 2
+fi
+
+if ! cargo clippy --workspace --all-targets --all-features -- -D warnings 2>&1; then
+    echo "Clippy (--all-features) failed." >&2
+    exit 2
+fi
+
+if ! cargo clippy --workspace --all-targets --no-default-features -- -D warnings 2>&1; then
+    echo "Clippy (--no-default-features) failed." >&2
+    exit 2
+fi
+
+if ! RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps 2>&1; then
+    echo "Doc check failed." >&2
+    exit 2
+fi
+
+echo "All pre-push checks passed." >&2
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,17 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "if": "Bash(git push *)",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/pre-push.sh",
+            "timeout": 600
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,6 +10,18 @@
 Pre-push: clippy (both feature sets) + fmt. Never use `cargo check/build`.
 These checks apply before any push — new commits, rebases, cherry-picks, etc.
 
+### Pre-push Checks (enforced by Claude hook)
+
+A Claude hook in `.claude/settings.json` runs `.claude/hooks/pre-push.sh`
+before every `git push`. The push is blocked if any check fails. The checks:
+
+- `cargo +nightly fmt -- --check`
+- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
+- `cargo clippy --workspace --all-targets --no-default-features -- -D warnings`
+- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps`
+
+Clippy and doc warnings are hard failures.
+
 Release: creating a release includes publishing all crates to crates.io
 via `cargo publish` (in dependency order).
 


### PR DESCRIPTION
## Summary

- Adds a Claude Code `PreToolUse` hook that runs before every `git push`
- Runs format check, clippy (with `-D warnings`), and doc build (with `-D warnings`)
- Clippy and rustdoc warnings are hard failures that block the push
- Documents the enforced checks in CLAUDE.md

## Files

- `.claude/hooks/pre-push.sh` — the check script
- `.claude/settings.json` — hook configuration
- `CLAUDE.md` — updated with pre-push checks documentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)