### PR TITLE
feat(tx-cache): change BundleKey cursor to use target_block_number

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.16.3"
+version = "0.17.0"
 edition = "2021"
 rust-version = "1.87"
 authors = ["init4"]
@@ -34,19 +34,19 @@ debug = false
 incremental = false
 
 [workspace.dependencies]
-signet-bundle = { version = "0.16.3", path = "crates/bundle" }
-signet-constants = { version = "0.16.3", path = "crates/constants" }
-signet-evm = { version = "0.16.3", path = "crates/evm" }
-signet-extract = { version = "0.16.3", path = "crates/extract" }
-signet-journal = { version = "0.16.3", path = "crates/journal" }
-signet-node = { version = "0.16.3", path = "crates/node" }
-signet-orders = { version = "0.16.3", path = "crates/orders" }
-signet-sim = { version = "0.16.3", path = "crates/sim" }
-signet-types = { version = "0.16.3", path = "crates/types" }
-signet-tx-cache = { version = "0.16.3", path = "crates/tx-cache" }
-signet-zenith = { version = "0.16.3", path = "crates/zenith" }
+signet-bundle = { version = "0.17.0", path = "crates/bundle" }
+signet-constants = { version = "0.17.0", path = "crates/constants" }
+signet-evm = { version = "0.17.0", path = "crates/evm" }
+signet-extract = { version = "0.17.0", path = "crates/extract" }
+signet-journal = { version = "0.17.0", path = "crates/journal" }
+signet-node = { version = "0.17.0", path = "crates/node" }
+signet-orders = { version = "0.17.0", path = "crates/orders" }
+signet-sim = { version = "0.17.0", path = "crates/sim" }
+signet-types = { version = "0.17.0", path = "crates/types" }
+signet-tx-cache = { version = "0.17.0", path = "crates/tx-cache" }
+signet-zenith = { version = "0.17.0", path = "crates/zenith" }
 
-signet-test-utils = { version = "0.16.3", path = "crates/test-utils" }
+signet-test-utils = { version = "0.17.0", path = "crates/test-utils" }
 
 # trevm
 trevm = { version = "0.34.2", features = ["full_env_cfg", "asyncdb"] }

--- a/crates/tx-cache/src/types.rs
+++ b/crates/tx-cache/src/types.rs
@@ -418,15 +418,18 @@ pub struct TxKey {
 }
 
 /// The query object keys for the bundle GET endpoint.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+///
+/// Cursor for the `block_number_index` GSI: paginates bundles for a given
+/// target block in score-descending order.
+#[derive(Debug, Copy, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct BundleKey {
-    /// The bundle id
+    /// The bundle id.
     pub id: Uuid,
-    /// The bundle score
+    /// The bundle score.
     pub score: u64,
-    /// The global bundle score key
-    pub global_bundle_score_key: String,
+    /// The bundle's target block number.
+    pub target_block_number: u64,
 }
 
 /// The query object keys for the order GET endpoint.
@@ -586,9 +589,9 @@ mod tests {
 
         let cache_response = CacheResponse::paginated(
             BundleList { bundles: vec![dummy_bundle_with_id(uuid)] },
-            BundleKey { id: uuid, score: 100, global_bundle_score_key: "gbsk".to_string() },
+            BundleKey { id: uuid, score: 100, target_block_number: 42 },
         );
-        let expected_json = r#"{"bundles":[{"id":"5932d4bb-58d9-41a9-851d-8dd7f04ccc33","bundle":{"txs":[],"blockNumber":"0x0","replacementUuid":"5932d4bb-58d9-41a9-851d-8dd7f04ccc33"}}],"nextCursor":{"id":"5932d4bb-58d9-41a9-851d-8dd7f04ccc33","score":100,"globalBundleScoreKey":"gbsk"}}"#;
+        let expected_json = r#"{"bundles":[{"id":"5932d4bb-58d9-41a9-851d-8dd7f04ccc33","bundle":{"txs":[],"blockNumber":"0x0","replacementUuid":"5932d4bb-58d9-41a9-851d-8dd7f04ccc33"}}],"nextCursor":{"id":"5932d4bb-58d9-41a9-851d-8dd7f04ccc33","score":100,"targetBlockNumber":42}}"#;
         let serialized = serde_json::to_string(&cache_response).unwrap();
         assert_eq!(serialized, expected_json);
         let deserialized =


### PR DESCRIPTION
## Description

The bundle GET endpoint in tx-pool-webservice is being switched to a new `block_number_index` GSI that filters bundles to a single target block. The cursor must match the new GSI key schema, so `global_bundle_score_key` is replaced with `target_block_number` in `BundleKey`. `Copy` is added to the derive list since all fields are now `Copy`.

Breaking type change. `BundleKey` is opaque continuation state returned by the server and round-tripped by clients, so the SDK bump is the only mechanical fix required for downstream consumers.

Closes ENG-2234

## Related

- Consumer PR (gates this one): init4tech/tx-pool-webservice#281

## Testing

- [x] All `signet-tx-cache` lib tests pass against this change.
- [x] Test fixture updated for the new wire format (`targetBlockNumber` instead of `globalBundleScoreKey`).