### PR TITLE
chore: provide `new_unchecked` constructors for headers

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.17.0"
+version = "0.17.1"
 edition = "2021"
 rust-version = "1.87"
 authors = ["init4"]
@@ -34,19 +34,19 @@ debug = false
 incremental = false
 
 [workspace.dependencies]
-signet-bundle = { version = "0.17.0", path = "crates/bundle" }
-signet-constants = { version = "0.17.0", path = "crates/constants" }
-signet-evm = { version = "0.17.0", path = "crates/evm" }
-signet-extract = { version = "0.17.0", path = "crates/extract" }
-signet-journal = { version = "0.17.0", path = "crates/journal" }
-signet-node = { version = "0.17.0", path = "crates/node" }
-signet-orders = { version = "0.17.0", path = "crates/orders" }
-signet-sim = { version = "0.17.0", path = "crates/sim" }
-signet-types = { version = "0.17.0", path = "crates/types" }
-signet-tx-cache = { version = "0.17.0", path = "crates/tx-cache" }
-signet-zenith = { version = "0.17.0", path = "crates/zenith" }
+signet-bundle = { version = "0.17.1", path = "crates/bundle" }
+signet-constants = { version = "0.17.1", path = "crates/constants" }
+signet-evm = { version = "0.17.1", path = "crates/evm" }
+signet-extract = { version = "0.17.1", path = "crates/extract" }
+signet-journal = { version = "0.17.1", path = "crates/journal" }
+signet-node = { version = "0.17.1", path = "crates/node" }
+signet-orders = { version = "0.17.1", path = "crates/orders" }
+signet-sim = { version = "0.17.1", path = "crates/sim" }
+signet-types = { version = "0.17.1", path = "crates/types" }
+signet-tx-cache = { version = "0.17.1", path = "crates/tx-cache" }
+signet-zenith = { version = "0.17.1", path = "crates/zenith" }
 
-signet-test-utils = { version = "0.17.0", path = "crates/test-utils" }
+signet-test-utils = { version = "0.17.1", path = "crates/test-utils" }
 
 # trevm
 trevm = { version = "0.34.2", features = ["full_env_cfg", "asyncdb"] }

--- a/crates/types/src/primitives/header/v1.rs
+++ b/crates/types/src/primitives/header/v1.rs
@@ -18,6 +18,20 @@ use std::ops::Deref;
 pub struct SignetHeaderV1(Sealed<Header>);
 
 impl SignetHeaderV1 {
+    /// Construct a [`SignetHeaderV1`] without validating signet header invariants.
+    ///
+    /// # Safety (logical)
+    ///
+    /// The caller must ensure the header satisfies V1 invariants: all shared
+    /// fields at their defaults and both roots equal to [`EMPTY_ROOT_HASH`].
+    /// Passing an invalid header will not cause UB but will violate type-level
+    /// expectations that downstream code relies on.
+    ///
+    /// [`EMPTY_ROOT_HASH`]: alloy::consensus::constants::EMPTY_ROOT_HASH
+    pub fn new_unchecked(header: Header) -> Self {
+        Self(Sealed::new(header))
+    }
+
     /// Consume the wrapper, returning the inner [`Sealed<Header>`].
     pub fn into_inner(self) -> Sealed<Header> {
         self.0

--- a/crates/types/src/primitives/header/v2.rs
+++ b/crates/types/src/primitives/header/v2.rs
@@ -23,6 +23,20 @@ pub struct SignetHeaderV2(Sealed<Header>);
 
 #[allow(deprecated)]
 impl SignetHeaderV2 {
+    /// Construct a [`SignetHeaderV2`] without validating signet header invariants.
+    ///
+    /// # Safety (logical)
+    ///
+    /// The caller must ensure the header satisfies V2 invariants: all shared
+    /// fields at their defaults and both roots **not** equal to
+    /// [`EMPTY_ROOT_HASH`]. Passing an invalid header will not cause UB but
+    /// will violate type-level expectations that downstream code relies on.
+    ///
+    /// [`EMPTY_ROOT_HASH`]: alloy::consensus::constants::EMPTY_ROOT_HASH
+    pub fn new_unchecked(header: Header) -> Self {
+        Self(Sealed::new(header))
+    }
+
     /// Consume the wrapper, returning the inner [`Sealed<Header>`].
     pub fn into_inner(self) -> Sealed<Header> {
         self.0


### PR DESCRIPTION
## Summary

- Add `new_unchecked` constructors to `SignetHeaderV1` and `SignetHeaderV2` that skip invariant validation, allowing infallible construction from trusted sources (e.g. headers already parsed and stored in the storage crates)
- Bump workspace version to 0.17.1

## Motivation

Storage crates store plain `alloy::consensus::Header` values. When reading these back and wrapping them as signet header types, the validation in `TryFrom<Header>` is redundant - the data has already been validated on the way in. The `new_unchecked` constructors allow direct construction without re-checking invariants, which is both simpler (infallible) and avoids unnecessary work.

## Test plan

- [x] Existing `signet-types` tests pass (`cargo t -p signet-types`)
- [x] Clippy clean with `--all-features` and `--no-default-features`
- [ ] Verify consuming crates can use `new_unchecked` to construct headers from stored data